### PR TITLE
Add add_executable_jar helper in Modules/UseJava.cmake

### DIFF
--- a/Modules/UseJava.cmake
+++ b/Modules/UseJava.cmake
@@ -68,6 +68,16 @@
 #   CLASS_DIR          The directory where the class files can be found. For
 #                      example to use them with javah.
 #
+# add_executable_jar(TARGET_NAME, ENTRY_POINT,
+#                    SRC1 SRC2 .. SRCN RCS1 RCS2 .. RCSN
+#                   )
+#
+# This command creates an executable <TARGET_NAME>.jar, by setting its
+# entry point to ENTRY_POINT. It compiles the given source files (SRC)
+# and adds the given resource files (RCS) to the jar file.
+# If only resource files are given then just a jar file is created.
+# Note: This command handles all add_jar()'s additionnal instructions.
+#
 # find_jar(<VAR>
 #          name | NAMES name1 [name2 ...]
 #          [PATHS path1 [path2 ... ENV var]]


### PR DESCRIPTION
I did not find a way to create an executable jar, i.e: set the entry point on jar building.

I've made a patch to add the function add_executable_jar.

The add_executable_jar function just heads the add_jar function, by setting specific parameters before calling add_jar and unset them right after it.
