### PR TITLE
Fix for bug #12618 : avoid to sleep for 3 seconds in ctest if cdash DropLocation is empty.

### DIFF
--- a/Source/cmCTest.cxx
+++ b/Source/cmCTest.cxx
@@ -440,8 +440,12 @@ std::string cmCTest::GetCDashVersion()
   std::string cdashUri = this->GetCTestConfiguration("DropLocation");
   cdashUri = cdashUri.substr(0, cdashUri.find("/submit.php"));
 
-  url += cdashUri + "/api/getversion.php";
-  int res = cmCTest::HTTPRequest(url, cmCTest::HTTP_GET, response, "", "", 3);
+  int res = 1;
+  if ( ! cdashUri.empty() )
+  {
+    url += cdashUri + "/api/getversion.php";
+    res = cmCTest::HTTPRequest(url, cmCTest::HTTP_GET, response, "", "", 3);
+  }
 
   return res ? this->GetCTestConfiguration("CDashVersion") : response;
 #else


### PR DESCRIPTION
To fix : http://public.kitware.com/Bug/view.php?id=12618
