### PR TITLE
Qt4Macros: Added support for generated resource files

### DIFF
--- a/Modules/Qt4Macros.cmake
+++ b/Modules/Qt4Macros.cmake
@@ -182,23 +182,31 @@ MACRO (QT4_ADD_RESOURCES outfiles )
     GET_FILENAME_COMPONENT(infile ${it} ABSOLUTE)
     GET_FILENAME_COMPONENT(rc_path ${infile} PATH)
     SET(outfile ${CMAKE_CURRENT_BINARY_DIR}/qrc_${outfilename}.cxx)
-    #  parse file for dependencies 
-    #  all files are absolute paths or relative to the location of the qrc file
-    FILE(READ "${infile}" _RC_FILE_CONTENTS)
-    STRING(REGEX MATCHALL "<file[^<]+" _RC_FILES "${_RC_FILE_CONTENTS}")
+
     SET(_RC_DEPENDS)
-    FOREACH(_RC_FILE ${_RC_FILES})
-      STRING(REGEX REPLACE "^<file[^>]*>" "" _RC_FILE "${_RC_FILE}")
-      IF(NOT IS_ABSOLUTE "${_RC_FILE}")
-        SET(_RC_FILE "${rc_path}/${_RC_FILE}")
-      ENDIF(NOT IS_ABSOLUTE "${_RC_FILE}")
-      SET(_RC_DEPENDS ${_RC_DEPENDS} "${_RC_FILE}")
-    ENDFOREACH(_RC_FILE)
-    # Since this cmake macro is doing the dependency scanning for these files,
-    # let's make a configured file and add it as a dependency so cmake is run
-    # again when dependencies need to be recomputed.
-    QT4_MAKE_OUTPUT_FILE("${infile}" "" "qrc.depends" out_depends)
-    CONFIGURE_FILE("${infile}" "${out_depends}" COPY_ONLY)
+    IF(EXISTS "${infile}")
+      #  parse file for dependencies 
+      #  all files are absolute paths or relative to the location of the qrc file
+      FILE(READ "${infile}" _RC_FILE_CONTENTS)
+      STRING(REGEX MATCHALL "<file[^<]+" _RC_FILES "${_RC_FILE_CONTENTS}")
+      FOREACH(_RC_FILE ${_RC_FILES})
+        STRING(REGEX REPLACE "^<file[^>]*>" "" _RC_FILE "${_RC_FILE}")
+        IF(NOT IS_ABSOLUTE "${_RC_FILE}")
+          SET(_RC_FILE "${rc_path}/${_RC_FILE}")
+        ENDIF(NOT IS_ABSOLUTE "${_RC_FILE}")
+        SET(_RC_DEPENDS ${_RC_DEPENDS} "${_RC_FILE}")
+      ENDFOREACH(_RC_FILE)
+      # Since this cmake macro is doing the dependency scanning for these files,
+      # let's make a configured file and add it as a dependency so cmake is run
+      # again when dependencies need to be recomputed.
+      QT4_MAKE_OUTPUT_FILE("${infile}" "" "qrc.depends" out_depends)
+      CONFIGURE_FILE("${infile}" "${out_depends}" COPY_ONLY)
+    ELSE(EXISTS "${infile}")
+      # The .qrc file does not exist (yet). Let's add a dependency and hope
+      # that it will be generated later
+      SET(out_depends)
+    ENDIF(EXISTS "${infile}")
+
     ADD_CUSTOM_COMMAND(OUTPUT ${outfile}
       COMMAND ${QT_RCC_EXECUTABLE}
       ARGS ${rcc_options} -name ${outfilename} -o ${outfile} ${infile}


### PR DESCRIPTION
Using the QT4_ADD_RESOURCES() macro required the resource file to exist already for dependency scanning. This prevented the use of resource files that are generated by cmake because it needs the file before resolving the dependency. This patch adds support for generated resource files by not scanning the resource file for dependencies if it doesn't exist yet. The add_custom_command() to generate the resource file should add the dependenies on the files used by the resource file.
