### PR TITLE
Add CMAKE_OSX_SDKSTRING to set SDKROOT string in pbxproj file

### DIFF
--- a/Source/cmGlobalXCodeGenerator.cxx
+++ b/Source/cmGlobalXCodeGenerator.cxx
@@ -3097,6 +3097,8 @@ void cmGlobalXCodeGenerator
                                 this->CreateString("YES"));
     }
 
+  const char* sdkString =
+      this->CurrentMakefile->GetDefinition("CMAKE_OSX_SDKSTRING");
   const char* sysroot =
       this->CurrentMakefile->GetDefinition("CMAKE_OSX_SYSROOT");
   const char* sysrootDefault =
@@ -3111,8 +3113,14 @@ void cmGlobalXCodeGenerator
     cmSystemTools::ExpandListArgument(std::string(osxArch),
                                       this->Architectures);
     flagsUsed = true;
-    buildSettings->AddAttribute("SDKROOT",
+
+    if (sdkString)
+        buildSettings->AddAttribute("SDKROOT",
+                                this->CreateString(sdkString));
+    else
+        buildSettings->AddAttribute("SDKROOT",
                                 this->CreateString(sysroot));
+
     std::string archString;
     const char* sep = "";
     for( std::vector<std::string>::iterator i =


### PR DESCRIPTION
The existing SDKROOT variable is insufficient, because it is
required that it be a path.  However, there are additional
valid values for SDKROOT in the pbxproj, such as "iphoneos"

This variable allows the use of these magic strings
