### PR TITLE
Added a dummy user agent string

### DIFF
--- a/Source/cmFileCommand.cxx
+++ b/Source/cmFileCommand.cxx
@@ -2857,6 +2857,11 @@ cmFileCommand::HandleDownloadCommand(std::vector<std::string> const& args)
   res = ::curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
   check_curl_result(res, "DOWNLOAD cannot set http failure option: ");
 
+  res = ::curl_easy_setopt(curl, CURLOPT_USERAGENT, "Mozilla/5.0 (Windows; U; "
+    "Windows NT 5.1; ru; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7 "
+    "(.NET CLR 3.5.30729)");
+  check_curl_result(res, "DOWNLOAD cannot set user agent option: ");
+
   res = ::curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION,
                            cmWriteToFileCallback);
   check_curl_result(res, "DOWNLOAD cannot set write function: ");


### PR DESCRIPTION
Some servers don't like it when no user string is provided. For example:

```
$ curl -A "" -v http://dist.schmorp.de/libev/Attic/libev-4.11.tar.gz
* About to connect() to dist.schmorp.de port 80 (#0)
*   Trying 176.9.46.141... connected
> GET /libev/Attic/libev-4.11.tar.gz HTTP/1.1
> Host: dist.schmorp.de
> Accept: */*
> 
< HTTP/1.1 500 blocked for one hour
< Date: Fri, 14 Sep 2012 07:56:58 GMT
< Server: nethype ews/1.3.41 (Unix) mod_perl/1.30 mod_ssl/2.8.31 OpenSSL/0.9.8o
< Connection: close
< Transfer-Encoding: chunked
< Content-Type: text/plain; charset=utf-8
< 
Your IP has been blocked for one hour due to your User-Agent. Please supply
a valid and informative User-Agent value to avoid a block in the future.

See RFC 2616, section 14.43.

Typical reasons for being blocked:

* spider not specifying URL or other contact information.
* spider camouflaging as normal browser.
* spider with no well-explained purpose.
* no user-agent given.
* known spambot signature.
* Closing connection #0
$
```

This change adds a dummy user agent string which makes it possible to download the file http://dist.schmorp.de/libev/Attic/libev-4.11.tar.gz using file(DOWNLOAD http://dist.schmorp.de/libev/Attic/libev-4.11.tar.gz libev.tar.gz)
