### PR TITLE
VS: Allow overriding the platform toolset in VS10+ (#13774)

### DIFF
--- a/Source/cmGlobalVisualStudio10Generator.cxx
+++ b/Source/cmGlobalVisualStudio10Generator.cxx
@@ -83,7 +83,8 @@ cmGlobalVisualStudio10Generator::cmGlobalVisualStudio10Generator(
 void cmGlobalVisualStudio10Generator::AddPlatformDefinitions(cmMakefile* mf)
 {
   cmGlobalVisualStudio8Generator::AddPlatformDefinitions(mf);
-  if(!this->PlatformToolset.empty())
+  if(!this->PlatformToolset.empty() &&
+     mf->GetDefinition("CMAKE_VS_PLATFORM_TOOLSET") == 0)
     {
     mf->AddDefinition("CMAKE_VS_PLATFORM_TOOLSET",
                       this->PlatformToolset.c_str());

--- a/Source/cmLocalVisualStudio10Generator.cxx
+++ b/Source/cmLocalVisualStudio10Generator.cxx
@@ -117,6 +117,17 @@ void cmLocalVisualStudio10Generator
                   cmCacheManager::INTERNAL);
 }
 
+const char* cmLocalVisualStudio10Generator::GetPlatformToolset() const
+{
+  if(const char* toolset =
+     this->Makefile->GetDefinition("CMAKE_VS_PLATFORM_TOOLSET"))
+    {
+    return toolset;
+    }
+  return static_cast<cmGlobalVisualStudio10Generator*>(this->GlobalGenerator)
+         ->GetPlatformToolset();
+}
+
 //----------------------------------------------------------------------------
 const char* cmLocalVisualStudio10Generator::ReportErrorLabel() const
 {

--- a/Source/cmLocalVisualStudio10Generator.h
+++ b/Source/cmLocalVisualStudio10Generator.h
@@ -37,6 +37,9 @@ public:
   virtual void ReadAndStoreExternalGUID(const char* name,
                                         const char* path);
 
+  /** The toolset name for the target platform.  */
+  const char* GetPlatformToolset() const;
+
 protected:
   virtual const char* ReportErrorLabel() const;
   virtual bool CustomCommandUseLocal() const { return true; }

--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -18,7 +18,7 @@
 #include "cmMakefile.h"
 #include "cmSourceFile.h"
 #include "cmVisualStudioGeneratorOptions.h"
-#include "cmLocalVisualStudio7Generator.h"
+#include "cmLocalVisualStudio10Generator.h"
 #include "cmVS10CLFlagTable.h"
 #include "cmVS10LinkFlagTable.h"
 #include "cmVS10LibFlagTable.h"
@@ -93,8 +93,8 @@ cmVisualStudio10TargetGenerator(cmTarget* target,
   this->GeneratorTarget = gg->GetGeneratorTarget(target);
   this->Makefile = target->GetMakefile();
   this->LocalGenerator =
-    (cmLocalVisualStudio7Generator*)
-    this->Makefile->GetLocalGenerator();
+    static_cast<cmLocalVisualStudio10Generator*>(
+    this->Makefile->GetLocalGenerator());
   this->Name = this->Target->GetName();
   this->GlobalGenerator->CreateGUID(this->Name.c_str());
   this->GUID = this->GlobalGenerator->GetGUID(this->Name.c_str());
@@ -443,7 +443,7 @@ void cmVisualStudio10TargetGenerator::WriteProjectConfigurationValues()
       {
       this->WriteString("<CharacterSet>MultiByte</CharacterSet>\n", 2);
       }
-    if(const char* toolset = gg->GetPlatformToolset())
+    if(const char* toolset = this->LocalGenerator->GetPlatformToolset())
       {
       std::string pts = "<PlatformToolset>";
       pts += toolset;

--- a/Source/cmVisualStudio10TargetGenerator.h
+++ b/Source/cmVisualStudio10TargetGenerator.h
@@ -20,7 +20,7 @@ class cmGeneratedFileStream;
 class cmGlobalVisualStudio10Generator;
 class cmSourceFile;
 class cmCustomCommand;
-class cmLocalVisualStudio7Generator;
+class cmLocalVisualStudio10Generator;
 class cmComputeLinkInformation;
 class cmVisualStudioGeneratorOptions;
 #include "cmSourceGroup.h"
@@ -107,7 +107,7 @@ private:
   std::string Name;
   cmGlobalVisualStudio10Generator* GlobalGenerator;
   cmGeneratedFileStream* BuildFileStream;
-  cmLocalVisualStudio7Generator* LocalGenerator;
+  cmLocalVisualStudio10Generator* LocalGenerator;
   std::set<cmSourceFile*> SourcesVisited;
 
   typedef std::map<cmStdString, ToolSources> ToolSourceMap;


### PR DESCRIPTION
Allow setting CMAKE_VS_PLATFORM_TOOLSET, as discussed in the issue notes.
