### PR TITLE
Ninja: Avoid LNK1170 linker error 

### DIFF
--- a/Source/cmNinjaNormalTargetGenerator.cxx
+++ b/Source/cmNinjaNormalTargetGenerator.cxx
@@ -190,7 +190,7 @@ cmNinjaNormalTargetGenerator
         linkOptionVar += cmTarget::GetTargetTypeName(targetType);
         const std::string linkOption =
                 GetMakefile()->GetSafeDefinition(linkOptionVar.c_str());
-        rspcontent = "$in " + linkOption + " $LINK_PATH $LINK_LIBRARIES";
+        rspcontent = "$in_newline " + linkOption + " $LINK_PATH $LINK_LIBRARIES";
         vars.Objects = responseFlag.c_str();
         vars.LinkLibraries = "";
     }


### PR DESCRIPTION
link.exe has problems with very very long lines in rsp files too.
Use $in_newline instead of $in variable for rspcontent which
separates the arguments with a newline instead of a simple space
and was specially made for this purpose.
