### PR TITLE
Use GmakeErrorParser instead of deprecated MakeErrorParser (fixes bug 0013699)

### DIFF
--- a/Source/cmExtraEclipseCDT4Generator.cxx
+++ b/Source/cmExtraEclipseCDT4Generator.cxx
@@ -39,6 +39,7 @@ cmExtraEclipseCDT4Generator
 
   this->SupportsVirtualFolders = true;
   this->GenerateLinkedResources = true;
+  this->SupportsGmakeErrorParser = true;
 }
 
 //----------------------------------------------------------------------------
@@ -76,6 +77,10 @@ void cmExtraEclipseCDT4Generator::Generate()
       if (version < 3006) // 3.6 is Helios
         {
         this->SupportsVirtualFolders = false;
+        }
+      if (version < 3007) // 3.7 is Indigo
+        {
+        this->SupportsGmakeErrorParser = false;
         }
       }
     }
@@ -403,8 +408,17 @@ void cmExtraEclipseCDT4Generator::CreateProjectFile()
     {
     fout << "org.eclipse.cdt.core.ICCErrorParser;";
     }
+
+  if (this->SupportsGmakeErrorParser)
+    {
+    fout << "org.eclipse.cdt.core.GmakeErrorParser;";
+    }
+  else
+    {
+    fout << "org.eclipse.cdt.core.MakeErrorParser;";
+    }
+
   fout <<
-    "org.eclipse.cdt.core.MakeErrorParser;"
     "org.eclipse.cdt.core.GCCErrorParser;"
     "org.eclipse.cdt.core.GASErrorParser;"
     "org.eclipse.cdt.core.GLDErrorParser;"

--- a/Source/cmExtraEclipseCDT4Generator.h
+++ b/Source/cmExtraEclipseCDT4Generator.h
@@ -111,6 +111,7 @@ private:
   bool GenerateSourceProject;
   bool GenerateLinkedResources;
   bool SupportsVirtualFolders;
+  bool SupportsGmakeErrorParser;
 
 };
 


### PR DESCRIPTION
The proposed change fixes bug 0013699 (http://public.kitware.com/Bug/view.php?id=13699) "Errors are not cleared when rebuilding a CMake-generated Eclipse CDT project" by using GmakeErrorParser instead of deprecated MakeErrorParser.
