### PR TITLE
providing an upgrade guid for wix in CPACK_WIX_UPGRADE_GUID

### DIFF
--- a/CMakeCPack.cmake
+++ b/CMakeCPack.cmake
@@ -113,6 +113,8 @@ if(EXISTS "${CMAKE_ROOT}/Modules/CPack.cmake")
     include(Utilities/Release/Cygwin/CMakeLists.txt)
   endif()
 
+  set(CPACK_WIX_UPGRADE_GUID "8ffd1d72-b7f1-11e2-8ee5-00238bca4991")
+
   # Set the options file that needs to be included inside CMakeCPackOptions.cmake
   set(QT_DIALOG_CPACK_OPTIONS_FILE ${CMake_BINARY_DIR}/Source/QtDialog/QtDialogCPack.cmake)
   configure_file("${CMake_SOURCE_DIR}/CMakeCPackOptions.cmake.in"


### PR DESCRIPTION
Without this upgrade GUID, you end up with multiple instances of the same installation when installing cmake from a WIX generated installer.
