### PR TITLE
Addition of VS_GLOBAL_ROOTNAMESPACE

### DIFF
--- a/Source/cmTarget.cxx
+++ b/Source/cmTarget.cxx
@@ -1328,6 +1328,11 @@ void cmTarget::DefineProperties(cmake *cm)
      "this value with \"ManagedCProj\", for example, in a Visual "
      "Studio managed C++ unit test project.");
   cm->DefineProperty
+    ("VS_GLOBAL_ROOTNAMESPACE", cmProperty::TARGET,
+     "Visual Studio project keyword.",
+     "Sets the \"RootNamespace\" attribute for a generated Visual Studio "
+     "project. Defaults to empty and is not output unless set.");
+  cm->DefineProperty
     ("VS_DOTNET_REFERENCES", cmProperty::TARGET,
      "Visual Studio managed project .NET references",
      "Adds one or more semicolon-delimited .NET references to a "

--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -262,6 +262,15 @@ void cmVisualStudio10TargetGenerator::Generate()
       "</Keyword>\n";
     }
 
+  const char* vsGlobalRootNamespace =
+    this->Target->GetProperty("VS_GLOBAL_ROOTNAMESPACE");
+  if(vsGlobalRootNamespace)
+    {
+    this->WriteString("<RootNamespace>", 2);
+    (*this->BuildFileStream) << cmVS10EscapeXML(vsGlobalRootNamespace) <<
+      "</RootNamespace>\n";
+    }
+
   this->WriteString("<Platform>", 2);
   (*this->BuildFileStream) << this->Platform << "</Platform>\n";
   const char* projLabel = this->Target->GetProperty("PROJECT_LABEL");


### PR DESCRIPTION
Added a variable for Visual Studio projects to set the root namespace in
the "Globals" PropertyGroup section of the project file.  This is required for some Visual Studio-based scripts to properly work.
