### PR TITLE
A couple of fixes to FindGTK2.cmake

### DIFF
--- a/Modules/FindGTK2.cmake
+++ b/Modules/FindGTK2.cmake
@@ -164,6 +164,7 @@ function(_GTK2_FIND_INCLUDE_DIR _var _hdr)
         cairo
         cairomm-1.0
         gdk-pixbuf-2.0
+        gthread-2.0
         gdkmm-2.4
         giomm-2.4
         gtk-2.0
@@ -464,6 +465,8 @@ foreach(_GTK2_component ${GTK2_FIND_COMPONENTS})
 
         _GTK2_FIND_INCLUDE_DIR(GTK2_GDK_PIXBUF_INCLUDE_DIR gdk-pixbuf/gdk-pixbuf.h)
         _GTK2_FIND_LIBRARY    (GTK2_GDK_PIXBUF_LIBRARY gdk_pixbuf false true)
+
+        _GTK2_FIND_LIBRARY    (GTK2_GTHREAD_LIBRARY gthread false true)
 
         _GTK2_FIND_LIBRARY    (GTK2_GIO_LIBRARY gio false true)
 


### PR DESCRIPTION
1) The pangocairo module is not detected on windows because the vcX is not appended to the filename.
Moreover it should be detected together with gtk, not with gtkmm

2) The gthread library is not detected.
