### PR TITLE
Generated dependency paths may be too long for projects with relative includes

### DIFF
--- a/Source/cmDependsC.cxx
+++ b/Source/cmDependsC.cxx
@@ -193,17 +193,7 @@ bool cmDependsC::WriteDependencies(const std::set<std::string>& sources,
           // Construct the name of the file as if it were in the current
           // include directory.  Avoid using a leading "./".
 
-          tempPathStr = "";
-          if((*i) == ".")
-            {
-            tempPathStr += current.FileName;
-            }
-          else
-            {
-            tempPathStr += *i;
-            tempPathStr+="/";
-            tempPathStr+=current.FileName;
-            }
+          tempPathStr = cmSystemTools::CollapsePath(*i, current.FileName);
 
           // Look for the file in this location.
           if(cmSystemTools::FileExists(tempPathStr.c_str(), true))
@@ -458,9 +448,7 @@ void cmDependsC::Scan(std::istream& is, const char* directory,
         // This was a double-quoted include with a relative path.  We
         // must check for the file in the directory containing the
         // file we are scanning.
-        entry.QuotedLocation = directory;
-        entry.QuotedLocation += "/";
-        entry.QuotedLocation += entry.FileName;
+        entry.QuotedLocation = cmSystemTools::CollapsePath(directory, entry.FileName);
         }
 
       // Queue the file if it has not yet been encountered and it

--- a/Source/cmSystemTools.cxx
+++ b/Source/cmSystemTools.cxx
@@ -1594,6 +1594,29 @@ std::string cmSystemTools::RelativePath(const char* local, const char* remote)
   return cmsys::SystemTools::RelativePath(local, remote);
 }
 
+std::string cmSystemTools::CollapsePath(const std::string &dir, const std::string &file)
+{
+  if (dir.empty() || dir == ".")
+    return file;
+
+  std::vector<std::string> dirComponents, fileComponents;;
+  cmSystemTools::SplitPath(dir.c_str(), dirComponents);
+  cmSystemTools::SplitPath(file.c_str(), fileComponents);
+
+  if (fileComponents[0] != "") // Not relative path
+    return file;
+
+  std::vector<std::string>::iterator i = fileComponents.begin();
+  while (dirComponents.size() > 1 && ++i != fileComponents.end())
+  {
+    if (*i != "..") break;
+    dirComponents.pop_back();
+  }
+
+  dirComponents.insert(dirComponents.end(), i, fileComponents.end());
+  return cmSystemTools::JoinPath(dirComponents);
+}
+
 #ifdef CMAKE_BUILD_WITH_CMAKE
 //----------------------------------------------------------------------
 bool cmSystemTools::UnsetEnv(const char* value)

--- a/Source/cmSystemTools.h
+++ b/Source/cmSystemTools.h
@@ -365,6 +365,11 @@ public:
   */
   static std::string RelativePath(const char* local, const char* remote);
 
+  /** Joins two paths while collapsing x/../ parts
+   * For example CollapsePath("a/b/c", "../../d") results in "a/d"
+   */
+  static std::string CollapsePath(const std::string &dir, const std::string &file);
+
 #ifdef CMAKE_BUILD_WITH_CMAKE
   /** Remove an environment variable */
   static bool UnsetEnv(const char* value);


### PR DESCRIPTION
When cmake calculates dependencies for C/C++ files with relative include clauses result paths are constructed with simple append header_path + '/' + inner_header_path.

This leads to depend file like 

``` make
CMakeFiles/test.dir/test.c.o: ../s1/../s2/f2.h
CMakeFiles/test.dir/test.c.o: ../s1/../s2/s2.2/../../s3/f3.h
CMakeFiles/test.dir/test.c.o: ../s1/../s2/s2.2/f2.2.h
CMakeFiles/test.dir/test.c.o: ../s1/f1.h
```

instead of

``` make
CMakeFiles/test.dir/test.c.o: ../s1/f1.h
CMakeFiles/test.dir/test.c.o: ../s2/f2.h
CMakeFiles/test.dir/test.c.o: ../s2/s2.2/f2.2.h
CMakeFiles/test.dir/test.c.o: ../s3/f3.h
```

With long chain of includes it may result in broken makefiles with paths larger then MAXPATH on win32 (260 chars).
