### PR TITLE
FindFreetype: Detect Freetype installed by GtkMM installer for win

### DIFF
--- a/Modules/FindFreetype.cmake
+++ b/Modules/FindFreetype.cmake
@@ -50,6 +50,9 @@ find_path(FREETYPE_INCLUDE_DIR_ft2build ft2build.h
     /usr/local/X11R6
     /usr/local/X11
     /usr/freeware
+    ENV GTKMM_BASEPATH
+    [HKEY_CURRENT_USER\\SOFTWARE\\gtkmm\\2.4;Path]
+    [HKEY_LOCAL_MACHINE\\SOFTWARE\\gtkmm\\2.4;Path]
   PATH_SUFFIXES include/freetype2 include
 )
 
@@ -61,6 +64,9 @@ find_path(FREETYPE_INCLUDE_DIR_freetype2 freetype/config/ftheader.h
     /usr/local/X11R6
     /usr/local/X11
     /usr/freeware
+    ENV GTKMM_BASEPATH
+    [HKEY_CURRENT_USER\\SOFTWARE\\gtkmm\\2.4;Path]
+    [HKEY_LOCAL_MACHINE\\SOFTWARE\\gtkmm\\2.4;Path]
   PATH_SUFFIXES include/freetype2 include
 )
 
@@ -70,10 +76,13 @@ find_library(FREETYPE_LIBRARY
     ENV FREETYPE_DIR
   PATH_SUFFIXES lib
   PATHS
-  /usr/X11R6
-  /usr/local/X11R6
-  /usr/local/X11
-  /usr/freeware
+    /usr/X11R6
+    /usr/local/X11R6
+    /usr/local/X11
+    /usr/freeware
+    ENV GTKMM_BASEPATH
+    [HKEY_CURRENT_USER\\SOFTWARE\\gtkmm\\2.4;Path]
+    [HKEY_LOCAL_MACHINE\\SOFTWARE\\gtkmm\\2.4;Path]
 )
 
 # set the user variables


### PR DESCRIPTION
FindFreetype fails to detect Freetype library installed by GtkMM windows installer. This causes issues also with the FindGTK2 module that uses it internally.

This patch adds to the search path, the same paths used by FindGTK2 module
