### PR TITLE
Adding Resx configuration to the vcxproj file.

### DIFF
--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -300,7 +300,7 @@ void cmVisualStudio10TargetGenerator::Generate()
   this->WriteCustomCommands();
   this->WriteAllSources();
   this->WriteDotNetReferences();
-
+  this->WriteEmbeddedResourceGroup();  
   this->WriteWinRTReferences();
   this->WriteProjectReferences();
   this->WriteString(
@@ -334,6 +334,46 @@ void cmVisualStudio10TargetGenerator::WriteDotNetReferences()
       this->WriteString("<ReferenceOutputAssembly>true"
                         "</ReferenceOutputAssembly>\n", 3);
       this->WriteString("</Reference>\n", 2);
+      }
+    this->WriteString("</ItemGroup>\n", 1);
+    }
+}
+
+void cmVisualStudio10TargetGenerator::WriteEmbeddedResourceGroup()
+{
+  const std::vector<cmSourceFile*> resxObjs = this->GeneratorTarget->ResxSources;
+  if(!resxObjs.empty())
+    {
+    this->WriteString("<ItemGroup>\n", 1);
+    for(std::vector<cmSourceFile*>::const_iterator oi = resxObjs.begin();
+        oi != resxObjs.end(); ++oi)
+      {
+      std::string obj = (*oi)->GetFullPath();
+      this->WriteString("<EmbeddedResource Include=\"", 2);
+      this->ConvertToWindowsSlash(obj);
+      (*this->BuildFileStream ) << obj << "\">\n";
+
+      this->WriteString("<DependentUpon>", 3);
+      std::string hFileName = obj.substr(0, obj.find_last_of(".")) + ".h";
+      (*this->BuildFileStream ) << hFileName;
+      this->WriteString("</DependentUpon>\n", 3);
+
+      this->GlobalGenerator->GetConfigurations();
+      const std::vector<std::string> *configs = this->GlobalGenerator->GetConfigurations();
+      for(std::vector<std::string>::const_iterator i = configs->begin();
+          i != configs->end(); ++i)
+        {
+        this->WritePlatformConfigTag("LogicalName", i->c_str(), 3);
+        if(this->Target->GetProperty("VS_GLOBAL_ROOTNAMESPACE"))
+          {
+            (*this->BuildFileStream ) << "$(RootNamespace).";
+          }
+        (*this->BuildFileStream ) << "%(Filename)";
+        (*this->BuildFileStream ) << ".resources";
+        (*this->BuildFileStream ) << "</LogicalName>\n";
+        }
+
+      this->WriteString("</EmbeddedResource>\n", 2);
       }
     this->WriteString("</ItemGroup>\n", 1);
     }
@@ -464,11 +504,6 @@ void cmVisualStudio10TargetGenerator::WriteProjectConfigurationValues()
       {
       this->WriteString("<WindowsAppContainer>true"
                         "</WindowsAppContainer>\n", 2);
-      }
-
-    if(!this->GeneratorTarget->ResxSources.empty())
-      {
-      this->WriteString("<CLRSupport>true</CLRSupport>\n", 2);
       }
 
     this->WriteString("</PropertyGroup>\n", 1);
@@ -663,11 +698,11 @@ void cmVisualStudio10TargetGenerator::WriteGroups()
     this->WriteGroupSources(ti->first.c_str(), ti->second, sourceGroups);
     }
 
-  std::vector<cmSourceFile*> resxObjs = this->GeneratorTarget->ResxSources;
+  const std::vector<cmSourceFile*> resxObjs = this->GeneratorTarget->ResxSources;
   if(!resxObjs.empty())
     {
     this->WriteString("<ItemGroup>\n", 1);
-    for(std::vector<cmSourceFile*>::iterator oi = resxObjs.begin();
+    for(std::vector<cmSourceFile*>::const_iterator oi = resxObjs.begin();
         oi != resxObjs.end(); ++oi)
       {
       std::string obj = (*oi)->GetFullPath();
@@ -1799,3 +1834,4 @@ bool cmVisualStudio10TargetGenerator::
 
   return it != this->GeneratorTarget->ExpectedResxHeaders.end();
 }
+

--- a/Source/cmVisualStudio10TargetGenerator.h
+++ b/Source/cmVisualStudio10TargetGenerator.h
@@ -59,6 +59,7 @@ private:
   void WriteSources(const char* tool, std::vector<cmSourceFile*> const&);
   void WriteAllSources();
   void WriteDotNetReferences();
+  void WriteEmbeddedResourceGroup();
   void WriteWinRTReferences();
   void WritePathAndIncrementalLinkOptions();
   void WriteItemDefinitionGroups();
@@ -116,3 +117,4 @@ private:
 };
 
 #endif
+

--- a/Tests/VSWindowsFormsResx/CMakeLists.txt
+++ b/Tests/VSWindowsFormsResx/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TARGET_SRC
   WindowsFormsResx/MyForm.cpp
   WindowsFormsResx/Source.cpp
   )
+set_source_files_properties(${TARGET_SRC} PROPERTIES COMPILE_FLAGS "/clr")
 
 set(TARGET_RESX
   WindowsFormsResx/MyForm.resx
@@ -42,3 +43,4 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DOTNET_REFERENCES "System" "Syst
 # Note: Modification of compiler flags is required for CLR compatibility now that we are using .resx files.
 string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+


### PR DESCRIPTION
In my project group we are using CMake to generate c++/cli winform
projects and I noticed the work done in "VS: Add Windows Forms Support"
was in the right direction for solving some of the problems we were
facing.

The changes as submitted was breaking some functionality in our
projects, so I made some changes that fixes our problems and I believe
that it will also work for others.

1) Resx files did not link correctly with the winform h-file so I added
the Resx configuration to the vcxproj file.

2) I removed the functionality for setting <CLRSupport> true for the
project - based on if an resx-file is pressent. This is preventing us
from using native cpp code.
Also this do not address that some projects will need to set other
options like clr:pure, clr:safe.
This could be implemented as a cmake option, so it is possible to
specify exactly what is needed.
Existing VSWindowsFormsResx Test project is updated so it will be
working with my changes.
