### PR TITLE
FindGTK2: Use GTK_XXX_LIBRARY_DEBUG libraries in debug mode

### DIFF
--- a/Modules/FindGTK2.cmake
+++ b/Modules/FindGTK2.cmake
@@ -321,7 +321,7 @@ function(_GTK2_FIND_LIBRARY _var _lib _expand_vc _append_version)
                        "While searching for ${_var}, our proposed library list is ${_lib_list}")
     endif()
 
-    find_library(${_var}
+    find_library(${_var}_RELEASE
         NAMES ${_lib_list}
         PATHS
             /opt/gnome/lib
@@ -346,23 +346,42 @@ function(_GTK2_FIND_LIBRARY _var _lib _expand_vc _append_version)
             [HKEY_LOCAL_MACHINE\\SOFTWARE\\gtkmm\\2.4;Path]/lib
         )
 
-        if(${_var} AND ${_var}_DEBUG)
-            if(NOT GTK2_SKIP_MARK_AS_ADVANCED)
-                mark_as_advanced(${_var}_DEBUG)
-            endif()
-            set(GTK2_LIBRARIES ${GTK2_LIBRARIES} optimized ${${_var}} debug ${${_var}_DEBUG})
-            set(GTK2_LIBRARIES ${GTK2_LIBRARIES} PARENT_SCOPE)
+        if(${_var}_RELEASE AND ${_var}_DEBUG)
+            set(${_var} optimized ${${_var}_RELEASE} debug ${${_var}_DEBUG})
+        elseif(${_var}_RELEASE)
+            set(${_var}_DEBUG ${_var}_DEBUG-NOTFOUND)
+            set(${_var} ${${_var}_RELEASE})
+        elseif(${_var}_DEBUG)
+            set(${_var}_RELEASE ${_var}_RELEASE-NOTFOUND)
+            set(${_var} ${${_var}_DEBUG})
         endif()
     else()
-        if(NOT GTK2_SKIP_MARK_AS_ADVANCED)
-            mark_as_advanced(${_var})
-        endif()
-        set(GTK2_LIBRARIES ${GTK2_LIBRARIES} ${${_var}})
-        set(GTK2_LIBRARIES ${GTK2_LIBRARIES} PARENT_SCOPE)
-        # Set debug to release
-        set(${_var}_DEBUG ${${_var}})
-        set(${_var}_DEBUG ${${_var}} PARENT_SCOPE)
+        set(${_var} ${${_var}_RELEASE})
+        # Set debug to not found
+        set(${_var}_DEBUG ${_var}_DEBUG-NOTFOUND)
     endif()
+
+    if(NOT GTK2_SKIP_MARK_AS_ADVANCED)
+        mark_as_advanced(${_var}_RELEASE)
+        mark_as_advanced(${_var}_DEBUG)
+    endif()
+
+    set(${_var}_DEBUG ${${_var}_DEBUG} PARENT_SCOPE)
+    set(${_var}_DEBUG ${${_var}_RELEASE} PARENT_SCOPE)
+    set(${_var} ${${_var}} PARENT_SCOPE)
+
+    set(GTK2_LIBRARIES ${GTK2_LIBRARIES} ${${_var}})
+    set(GTK2_LIBRARIES ${GTK2_LIBRARIES} PARENT_SCOPE)
+
+    if(GTK2_DEBUG)
+        message(STATUS "[FindGTK2.cmake:${CMAKE_CURRENT_LIST_LINE}]     "
+                       "${_var}_RELEASE = \"${${_var}_RELEASE}\"")
+        message(STATUS "[FindGTK2.cmake:${CMAKE_CURRENT_LIST_LINE}]     "
+                       "${_var}_DEBUG   = \"${${_var}_DEBUG}\"")
+        message(STATUS "[FindGTK2.cmake:${CMAKE_CURRENT_LIST_LINE}]     "
+                       "${_var}         = \"${${_var}}\"")
+    endif()
+
 endfunction()
 
 #=============================================================


### PR DESCRIPTION
If the GTK_XXX_LIBRARY_DEBUG library is available, it is now used when
linking in debug mode XXX.
A new set of variables GTK_XXX_LIBRARY_RELEASE is added and the
original GTK_XXX_LIBRARY uses the optimized/debug syntax.
