### PR TITLE
WiX Generator add support for custom wix templates

### DIFF
--- a/Modules/CPackWIX.cmake
+++ b/Modules/CPackWIX.cmake
@@ -76,6 +76,15 @@
 # This image must be 493 by 312 pixels.
 #
 ##end
+##variable
+# CPACK_WIX_TEMPLATE - Template file for WiX generation
+#
+# If this variable is set, the specified template will be used to generate the WiX wxs file.
+# This should be used if further customization of the output is required.
+#
+# If this variable is not set, the default MSI template included with CMake will be used.
+#
+##end
 
 #=============================================================================
 # Copyright 2012 Kitware, Inc.

--- a/Source/CPack/WiX/cmCPackWIXGenerator.cxx
+++ b/Source/CPack/WiX/cmCPackWIXGenerator.cxx
@@ -358,6 +358,10 @@ bool cmCPackWIXGenerator::CreateWiXSourceFiles()
   directoryDefinitions.EndElement();
 
   std::string wixTemplate = FindTemplate("WIX.template.in");
+  if(GetOption("CPACK_WIX_TEMPLATE") != 0)
+	{
+	wixTemplate = GetOption("CPACK_WIX_TEMPLATE");
+	}
   if(wixTemplate.empty())
     {
     cmCPackLogger(cmCPackLog::LOG_ERROR,


### PR DESCRIPTION
WiX provides a lot of functionality for installers that cannot be
supported (easily) in the default WIX.template.in file.

For most users, the default template should be fine.  However if users
want to produce merge modules, include custom actions, etc, this new
option allows for a hook into how the wxs is produced.
