### PR TITLE
Add option to use stdout/stderr of original terminal in cmake --build

### DIFF
--- a/Source/cmSystemTools.cxx
+++ b/Source/cmSystemTools.cxx
@@ -638,6 +638,12 @@ bool cmSystemTools::RunSingleCommand(std::vector<cmStdString>const& command,
     cmsysProcess_SetOption(cp, cmsysProcess_Option_HideWindow, 1);
     }
 
+  if (outputflag == OUTPUT_PASSTHROUGH)
+    {
+    cmsysProcess_SetPipeShared(cp, cmsysProcess_Pipe_STDOUT, 1);
+    cmsysProcess_SetPipeShared(cp, cmsysProcess_Pipe_STDERR, 1);
+    }
+
   cmsysProcess_SetTimeout(cp, timeout);
   cmsysProcess_Execute(cp);
 
@@ -645,7 +651,7 @@ bool cmSystemTools::RunSingleCommand(std::vector<cmStdString>const& command,
   char* data;
   int length;
   int pipe;
-  if ( output || outputflag != OUTPUT_NONE )
+  if(outputflag != OUTPUT_PASSTHROUGH && (output || outputflag != OUTPUT_NONE))
     {
     while((pipe = cmsysProcess_WaitForData(cp, &data, &length, 0)) > 0)
       {

--- a/Source/cmSystemTools.h
+++ b/Source/cmSystemTools.h
@@ -211,7 +211,7 @@ public:
    * user-viewable output from the program being run will be generated.
    * OUTPUT_MERGE is the legacy behaviour where stdout and stderr are merged
    * into stdout.  OUTPUT_NORMAL passes through the output to stdout/stderr as
-   * it was received.
+   * it was received.  OUTPUT_PASSTHROUGH passes through the original handles.
    *
    * If timeout is specified, the command will be terminated after
    * timeout expires. Timeout is specified in seconds.
@@ -230,7 +230,8 @@ public:
    {
      OUTPUT_NONE = 0,
      OUTPUT_MERGE,
-     OUTPUT_NORMAL
+     OUTPUT_NORMAL,
+     OUTPUT_PASSTHROUGH
    };
   static bool RunSingleCommand(const char* command, std::string* output = 0,
                                int* retVal = 0, const char* dir = 0,

--- a/Source/cmakemain.cxx
+++ b/Source/cmakemain.cxx
@@ -62,7 +62,10 @@ static const char * cmDocumentationDescription[][3] =
   "  --config <cfg> = For multi-configuration tools, choose <cfg>.\n"   \
   "  --clean-first  = Build target 'clean' first, then build.\n"        \
   "                   (To clean only, use --target 'clean'.)\n"         \
-  "  --use-stderr  =  Don't merge stdout/stderr.\n"                     \
+  "  --use-stderr   = Don't merge stdout/stderr output and pass the\n"  \
+  "                   original stdout/stderr handles to the native\n"   \
+  "                   tool so it can use the capabilities of the\n"     \
+  "                   calling terminal (e.g. colored output).\n"        \
   "  --             = Pass remaining options to the native tool.\n"
 
 //----------------------------------------------------------------------------
@@ -604,7 +607,7 @@ static int do_build(int ac, char** av)
       }
     else if(strcmp(av[i], "--use-stderr") == 0)
       {
-        outputflag = cmSystemTools::OUTPUT_NORMAL;
+      outputflag = cmSystemTools::OUTPUT_PASSTHROUGH;
       }
     else if(strcmp(av[i], "--") == 0)
       {


### PR DESCRIPTION
The new option --passthrough for the build command passes the original
handles of stdout and stderr to the native tool. This enables the
usage of advanced terminal features like colored output.
