### PR TITLE
fix for HP-UX building

### DIFF
--- a/Utilities/cmlibarchive/libarchive/archive_write_disk_posix.c
+++ b/Utilities/cmlibarchive/libarchive/archive_write_disk_posix.c
@@ -2869,21 +2869,22 @@ set_time_tru64(int fd, int mode, const char *name,
     time_t ctime, long ctime_nsec)
 {
 	struct attr_timbuf tstamp;
-	struct timeval times[3];
+#ifdef __hpux
+	tstamp.atime.tv_sec = atime;
+  tstamp.atime.tv_nsec = atime_nsec;
+  tstamp.mtime.tv_sec = mtime;
+  tstamp.mtime.tv_nsec = mtime_nsec;
+  tstamp.ctime.tv_sec = ctime;
+  tstamp.ctime.tv_nsec = ctime_nsec / 1000;
+#else // __hpux
+  struct timeval times[3];
 	times[0].tv_sec = atime;
 	times[0].tv_usec = atime_nsec / 1000;
 	times[1].tv_sec = mtime;
 	times[1].tv_usec = mtime_nsec / 1000;
 	times[2].tv_sec = ctime;
 	times[2].tv_usec = ctime_nsec / 1000;
-#ifdef __hpux
-	tstamp.atime.tv_sec = times[0].tv_sec;
-        tstamp.atime.tv_nsec = times[0].tv_usec * 1000;
-        tstamp.mtime.tv_sec = times[1].tv_sec;
-        tstamp.mtime.tv_nsec = times[1].tv_usec * 1000;
-        tstamp.ctime.tv_sec = times[2].tv_sec;
-        tstamp.ctime.tv_nsec = times[2].tv_usec * 1000;
-#else // __hpux
+
 	tstamp.atime = times[0];
 	tstamp.mtime = times[1];
 	tstamp.ctime = times[2];


### PR DESCRIPTION
After this workaround, it builds on HP-UX:
HP-UX migs01a B.11.31 U ia64 0841004181 unlimited-user license
aCC: HP C/aC++ B3910B A.06.20 [May 13 2008]

http://www.cmake.org/Bug/view.php?id=14386
