### PR TITLE
Fixed NPP library search for CUDA 5.5

### DIFF
--- a/Modules/FindCUDA.cmake
+++ b/Modules/FindCUDA.cmake
@@ -263,6 +263,12 @@
 #                           Only available for CUDA version 3.2+.
 #  CUDA_npp_LIBRARY      -- NVIDIA Performance Primitives library.
 #                           Only available for CUDA version 4.0+.
+#  CUDA_nppc_LIBRARY      -- NVIDIA Performance Primitives library (core).
+#                           Only available for CUDA version 5.5+.
+#  CUDA_nppi_LIBRARY      -- NVIDIA Performance Primitives library (image processing).
+#                           Only available for CUDA version 5.5+.
+#  CUDA_npps_LIBRARY      -- NVIDIA Performance Primitives library (signal processing).
+#                           Only available for CUDA version 5.5+.
 #  CUDA_nvcuvenc_LIBRARY -- CUDA Video Encoder library.
 #                           Only available for CUDA version 3.2+.
 #                           Windows only.


### PR DESCRIPTION
In CUDA 5.5 NPP was splitted onto 3 separate libraries : `nppc`, `npps` and `nppi`.
