### PR TITLE
Amend the documentation for list(APPEND) to show that elements are optional

### DIFF
--- a/Source/cmListCommand.h
+++ b/Source/cmListCommand.h
@@ -63,7 +63,7 @@ public:
       "  list(LENGTH <list> <output variable>)\n"
       "  list(GET <list> <element index> [<element index> ...]\n"
       "       <output variable>)\n"
-      "  list(APPEND <list> <element> [<element> ...])\n"
+      "  list(APPEND <list> [<element> ...])\n"
       "  list(FIND <list> <value> <output variable>)\n"
       "  list(INSERT <list> <element_index> <element> [<element> ...])\n"
       "  list(REMOVE_ITEM <list> <value> [<value> ...])\n"


### PR DESCRIPTION
`list(APPEND)` has been able to append nothing since commit a06dcdba9, but the documentation still used to imply that at least one argument is required.
