### PR TITLE
Add <CLRSupport> Tag for Visual Studio

### DIFF
--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -542,6 +542,10 @@ void cmVisualStudio10TargetGenerator::WriteProjectConfigurationValues()
       this->WriteString("<WindowsAppContainer>true"
                         "</WindowsAppContainer>\n", 2);
       }
+	if(!this->GeneratorTarget->ResxSources.empty())
+      {
+      this->WriteString("<CLRSupport>true</CLRSupport>\n", 2);
+      }
 
     this->WriteString("</PropertyGroup>\n", 1);
     }


### PR DESCRIPTION
Adds the ability to write out the <CLRSupport> tag into Visual Studio
project files when using .resx files.  This is necessary in addition to
the CLR compiler flag to allow the Visual Studio designer to work
consistently.
