### PR TITLE
Fix compilation on HP-UX 11.11 hppa

### DIFF
--- a/Source/kwsys/SystemInformation.cxx
+++ b/Source/kwsys/SystemInformation.cxx
@@ -4991,7 +4991,12 @@ bool SystemInformationImplementation::QueryHPUXProcessor()
     case CPU_PA_RISC2_0:
       this->ChipID.Vendor = "Hewlett-Packard";
       this->ChipID.Family = 0x200;
+#  ifdef CPU_HP_INTEL_EM_1_0
+    case CPU_HP_INTEL_EM_1_0:
+#  endif
+#  ifdef CPU_IA64_ARCHREV_0
     case CPU_IA64_ARCHREV_0:
+#  endif
       this->ChipID.Vendor = "GenuineIntel";
       this->Features.HasIA64 = true;
       break;


### PR DESCRIPTION
Some older versions of HP-UX do not define CPU_IA64_ARCHREV_0, but CPU_HP_INTEL_EM_1_0 resolves to the same constant (in /usr/include/sys/unistd.h).
