### PR TITLE
Fix storyboard view in Xcode.

### DIFF
--- a/Source/cmGlobalXCodeGenerator.cxx
+++ b/Source/cmGlobalXCodeGenerator.cxx
@@ -876,7 +876,10 @@ cmGlobalXCodeGenerator::CreateXCodeFileReferenceFromPath(
   else
     {
     std::string sourcecode = GetSourcecodeValueFromFileExtension(ext, lang);
-    fileRef->AddAttribute("explicitFileType",
+    const char* attribute = (sourcecode == "file.storyboard") ?
+                             "lastKnownFileType" :
+                             "explicitFileType";
+    fileRef->AddAttribute(attribute,
                           this->CreateString(sourcecode.c_str()));
     }
 


### PR DESCRIPTION
If storyboard file has attribute 'explicitFileType' it is displayed
incorrectly (as raw xml). Works fine with 'lastKnownFileType'.
