### PR TITLE
Leverage java_home command to help FindJava and FindJNI modules on Mac

### DIFF
--- a/Modules/FindJNI.cmake
+++ b/Modules/FindJNI.cmake
@@ -102,6 +102,12 @@ set(JAVA_AWT_LIBRARY_DIRECTORIES
 
 file(TO_CMAKE_PATH "$ENV{JAVA_HOME}" _JAVA_HOME)
 
+if(APPLE AND NOT EXISTS ${_JAVA_HOME})
+  execute_process(COMMAND /usr/libexec/java_home
+    OUTPUT_VARIABLE _JAVA_HOME OUTPUT_STRIP_TRAILING_WHITESPACE)
+  file(TO_CMAKE_PATH "${_JAVA_HOME}" _JAVA_HOME)
+endif()
+
 JAVA_APPEND_LIBRARY_DIRECTORIES(JAVA_AWT_LIBRARY_DIRECTORIES
   ${_JAVA_HOME}/jre/lib/{libarch}
   ${_JAVA_HOME}/jre/lib
@@ -186,7 +192,10 @@ foreach(JAVA_PROG "${JAVA_RUNTIME}" "${JAVA_COMPILE}" "${JAVA_ARCHIVE}")
   endforeach()
 endforeach()
 
-if(APPLE)
+set(_APPLE_FIND_FRAMEWORK ${CMAKE_FIND_FRAMEWORK})
+set(_REVERT_FIND_FRAMEWORK 0)
+
+if(APPLE AND EXISTS "${_JAVA_HOME}/bundle")
   if(EXISTS ~/Library/Frameworks/JavaVM.framework)
     set(JAVA_HAVE_FRAMEWORK 1)
   endif()
@@ -223,6 +232,12 @@ if(APPLE)
       )
   endif()
 else()
+  if(APPLE)
+    # Redefine CMAKE_FIND_FRAMEWORK to ensure Apple's frameworks are not searched first
+    # (is reverted back below)
+    set(_REVERT_FIND_FRAMEWORK 1)
+    set(CMAKE_FIND_FRAMEWORK LAST)
+  endif()
   find_library(JAVA_AWT_LIBRARY jawt
     PATHS ${JAVA_AWT_LIBRARY_DIRECTORIES}
   )
@@ -254,6 +269,11 @@ find_path(JAVA_AWT_INCLUDE_PATH jawt.h
 include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(JNI  DEFAULT_MSG  JAVA_AWT_LIBRARY JAVA_JVM_LIBRARY
                                                     JAVA_INCLUDE_PATH  JAVA_INCLUDE_PATH2 JAVA_AWT_INCLUDE_PATH)
+
+if(APPLE AND ${_REVERT_FIND_FRAMEWORK})
+  # Revert back to defined CMAKE_FIND_FRAMEWORK
+  set(CMAKE_FIND_FRAMEWORK ${_APPLE_FIND_FRAMEWORK})
+endif()
 
 mark_as_advanced(
   JAVA_AWT_LIBRARY

--- a/Modules/FindJava.cmake
+++ b/Modules/FindJava.cmake
@@ -67,6 +67,14 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
+file(TO_CMAKE_PATH "$ENV{JAVA_HOME}" _JAVA_HOME)
+
+if(APPLE AND NOT EXISTS ${_JAVA_HOME})
+  execute_process(COMMAND /usr/libexec/java_home
+    OUTPUT_VARIABLE _JAVA_HOME OUTPUT_STRIP_TRAILING_WHITESPACE)
+  file(TO_CMAKE_PATH "${_JAVA_HOME}" _JAVA_HOME)
+endif()
+
 # The HINTS option should only be used for values computed from the system.
 set(_JAVA_HINTS
   "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\2.0;JavaHome]/bin"
@@ -77,7 +85,7 @@ set(_JAVA_HINTS
   "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.5;JavaHome]/bin"
   "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.4;JavaHome]/bin"
   "[HKEY_LOCAL_MACHINE\\SOFTWARE\\JavaSoft\\Java Development Kit\\1.3;JavaHome]/bin"
-  $ENV{JAVA_HOME}/bin
+  ${_JAVA_HOME}/bin
   )
 # Hard-coded guesses should still go in PATHS. This ensures that the user
 # environment can always override hard guesses.


### PR DESCRIPTION
- See [issue #14689](http://www.cmake.org/Bug/view.php?id=14689) for full description
- Also includes related patch from [issue #14508](http://www.cmake.org/Bug/view.php?id=14508)
