### PR TITLE
Remember variable type in Add Entry

### DIFF
--- a/Source/QtDialog/AddCacheEntry.cxx
+++ b/Source/QtDialog/AddCacheEntry.cxx
@@ -22,8 +22,9 @@ static const QCMakeProperty::PropertyType Types[NumTypes] =
   { QCMakeProperty::BOOL, QCMakeProperty::PATH,
     QCMakeProperty::FILEPATH, QCMakeProperty::STRING};
 
-AddCacheEntry::AddCacheEntry(QWidget* p, const QStringList& completions)
-  : QWidget(p)
+AddCacheEntry::AddCacheEntry(QWidget* p, const QStringList& varNames,
+		                                     const QStringList& varTypes)
+  : QWidget(p), VarNames(varNames), VarTypes(varTypes)
 {
   this->setupUi(this);
   for(int i=0; i<NumTypes; i++)
@@ -44,7 +45,7 @@ AddCacheEntry::AddCacheEntry(QWidget* p, const QStringList& completions)
   this->setTabOrder(path, filepath);
   this->setTabOrder(filepath, string);
   this->setTabOrder(string, this->Description);
-	QCompleter *completer = new QCompleter(completions, this);
+	QCompleter *completer = new QCompleter(this->VarNames, this);
   this->Name->setCompleter(completer);
 	connect(completer, SIGNAL(activated(const QString&)),
 		      this, SLOT(onCompletionActivated(const QString&)));
@@ -96,10 +97,10 @@ QString AddCacheEntry::typeString() const
 
 void AddCacheEntry::onCompletionActivated(const QString &text)
 {
-	int pos = text.lastIndexOf(':');
-	if (pos != -1)
+	int idx = this->VarNames.indexOf(text);
+	if (idx != -1)
 		{
-		QString type = text.mid(pos + 1, text.length() - pos).toUpper();
+		QString type = this->VarTypes[idx];
 		for (int i = 0; i < NumTypes; i++)
 			{
 				if (TypeStrings[i] == type)

--- a/Source/QtDialog/AddCacheEntry.h
+++ b/Source/QtDialog/AddCacheEntry.h
@@ -24,7 +24,8 @@ class AddCacheEntry : public QWidget, public Ui::AddCacheEntry
 {
   Q_OBJECT
 public:
-  AddCacheEntry(QWidget* p, const QStringList& completions);
+  AddCacheEntry(QWidget* p, const QStringList& varNames,
+		                        const QStringList& varTypes);
 
   QString name() const;
   QVariant value() const;
@@ -34,6 +35,10 @@ public:
 
 private slots:
 	void onCompletionActivated(const QString &text);
+
+private:
+	const QStringList& VarNames;
+	const QStringList& VarTypes;
 };
 
 #endif

--- a/Source/QtDialog/CMakeSetupDialog.cxx
+++ b/Source/QtDialog/CMakeSetupDialog.cxx
@@ -70,8 +70,10 @@ CMakeSetupDialog::CMakeSetupDialog()
   restoreGeometry(settings.value("geometry").toByteArray());
   restoreState(settings.value("windowState").toByteArray());
 
-  this->AddVariableCompletions = settings.value("AddVariableCompletionEntries",
-                      QStringList("CMAKE_INSTALL_PREFIX:PATH")).toStringList();
+  this->AddVariableNames = settings.value("AddVariableNames",
+		                       QStringList("CMAKE_INSTALL_PREFIX")).toStringList();
+	this->AddVariableTypes = settings.value("AddVariableTypes",
+		                                       QStringList("PATH")).toStringList();
 
   QWidget* cont = new QWidget(this);
   this->setupUi(cont);
@@ -1049,7 +1051,8 @@ void CMakeSetupDialog::addCacheEntry()
   dialog.resize(400, 200);
   dialog.setWindowTitle(tr("Add Cache Entry"));
   QVBoxLayout* l = new QVBoxLayout(&dialog);
-  AddCacheEntry* w = new AddCacheEntry(&dialog, this->AddVariableCompletions);
+	AddCacheEntry* w = new AddCacheEntry(&dialog, this->AddVariableNames,
+		                                            this->AddVariableTypes);
   QDialogButtonBox* btns = new QDialogButtonBox(
       QDialogButtonBox::Ok | QDialogButtonBox::Cancel,
       Qt::Horizontal, &dialog);
@@ -1064,25 +1067,26 @@ void CMakeSetupDialog::addCacheEntry()
     m->insertProperty(w->type(), w->name(), w->description(), w->value(), false);
 
     // only add variable names to the completion which are new
-    if (!this->AddVariableCompletions.contains(w->name()))
+    if (!this->AddVariableNames.contains(w->name()))
       {
-			this->AddVariableCompletions << QString("%1:%2").arg(w->name(),
-				                                                   w->typeString());
+			this->AddVariableNames << w->name();
+			this->AddVariableTypes << w->typeString();
       // limit to at most 100 completion items
-      if (this->AddVariableCompletions.size() > 100)
+      if (this->AddVariableNames.size() > 100)
         {
-        this->AddVariableCompletions.removeFirst();
+        this->AddVariableNames.removeFirst();
+				this->AddVariableTypes.removeFirst();
         }
       // make sure CMAKE_INSTALL_PREFIX is always there
-      if (!this->AddVariableCompletions.contains("CMAKE_INSTALL_PREFIX:PATH") &&
-				  !this->AddVariableCompletions.contains("CMAKE_INSTALL_PREFIX"))
+      if (!this->AddVariableNames.contains("CMAKE_INSTALL_PREFIX"))
         {
-        this->AddVariableCompletions << QString("CMAKE_INSTALL_PREFIX:PATH");
+        this->AddVariableNames << "CMAKE_INSTALL_PREFIX";
+				this->AddVariableTypes << "PATH";
         }
       QSettings settings;
       settings.beginGroup("Settings/StartPath");
-      settings.setValue("AddVariableCompletionEntries",
-                        this->AddVariableCompletions);
+      settings.setValue("AddVariableNames", this->AddVariableNames);
+			settings.setValue("AddVariableTypes", this->AddVariableTypes);
       }
     }
 }

--- a/Source/QtDialog/CMakeSetupDialog.h
+++ b/Source/QtDialog/CMakeSetupDialog.h
@@ -110,7 +110,8 @@ protected:
   QTextCharFormat ErrorFormat;
   QTextCharFormat MessageFormat;
 
-  QStringList AddVariableCompletions;
+  QStringList AddVariableNames;
+  QStringList AddVariableTypes;
   QStringList FindHistory;
 
   QEventLoop LocalLoop;


### PR DESCRIPTION
Store variable types together with their names in the variable completion list so that the type is automatically recovered when you select a variable.

This also works for variables that were previously stored without a type, e.g. with an older version of CMake (the type is set to default).
