### PR TITLE
CTest: Remove need of usage of two variables in Coverage

### DIFF
--- a/Modules/CTest.cmake
+++ b/Modules/CTest.cmake
@@ -211,11 +211,19 @@ if(BUILD_TESTING)
   find_program(SCPCOMMAND scp DOC
     "Path to scp command, used by CTest for submitting results to a Dart server"
     )
-  find_program(COVERAGE_COMMAND gcov DOC
-    "Path to the coverage program that CTest uses for performing coverage inspection"
-    )
-  set(COVERAGE_EXTRA_FLAGS "-l" CACHE STRING
-    "Extra command line flags to pass to the coverage tool")
+  # CTEST_COVERAGE_COMMAND and CTEST_COVERAGE_EXTRA_FLAGS have precedence
+  # over COVERAGE_COMMAND and COVERAGE_EXTRA_FLAGS
+  SET_IF_SET_AND_NOT_SET(COVERAGE_COMMAND "${CTEST_COVERAGE_COMMAND}")
+  SET_IF_SET_AND_NOT_SET(COVERAGE_EXTRA_FLAGS "${CTEST_COVERAGE_EXTRA_FLAGS}")
+
+  # IF COVERAGE_COMMAND still not set, assign the gcov default values
+  IF(NOT COVERAGE_COMMAND)
+    find_program(COVERAGE_COMMAND gcov DOC
+      "Path to the coverage program that CTest uses for performing coverage
+      inspection")
+    set(COVERAGE_EXTRA_FLAGS "-l" CACHE STRING
+      "Extra command line flags to pass to the coverage tool")
+  endif()
 
   # set the site name
   site_name(SITE)

--- a/Source/CTest/cmCTestCoverageCommand.cxx
+++ b/Source/CTest/cmCTestCoverageCommand.cxx
@@ -23,8 +23,14 @@ cmCTestCoverageCommand::cmCTestCoverageCommand()
 //----------------------------------------------------------------------------
 cmCTestGenericHandler* cmCTestCoverageCommand::InitializeHandler()
 {
-  this->CTest->SetCTestConfigurationFromCMakeVariable(this->Makefile,
-    "CoverageCommand", "CTEST_COVERAGE_COMMAND");
+
+  if(this->Makefile->GetDefinition("CTEST_COVERAGE_COMMAND"))
+    {
+      this->CTest->SetCTestConfigurationFromCMakeVariable(this->Makefile,
+        "CoverageCommand", "CTEST_COVERAGE_COMMAND");
+      this->CTest->SetCTestConfigurationFromCMakeVariable(this->Makefile,
+        "CoverageExtraFlags", "CTEST_COVERAGE_EXTRA_FLAGS");
+    }
 
   cmCTestCoverageHandler* handler = static_cast<cmCTestCoverageHandler*>(
     this->CTest->GetInitializedHandler("coverage"));


### PR DESCRIPTION
Before, there were two variables for CoverageCommand and
CoverageExtraFlags. Both of them were needed to be used if
both script file and console is used for ctest.

COVERAGE_COMMAND & CTEST_COVERAGE_COMMAND
COVERAGE_EXTRA_FLAGS & CTEST_COVERAGE_EXTRA_FLAGS

In DartConfiguration file, the former ones were used to replace
the values. However, if you use a script file to do coverage on
source, script looks for the latter ones which fails the coverage
as they were not set (except for using set(COVERAGE_COMMAND "${CTEST_COVERAGE_COMMAND}")
in script).

Now, CTEST_COVERAGE_COMMAND has precedence over COVERAGE_COMMAND which
assigns itself to COVERAGE_COMMAND if COVERAGE_COMMAND is not set
explicitly. For backward compatibility, if CTEST_COVERAGE_COMMAND is
also not set, COVERAGE_COMMAND is reset to gcov and the FLAGS are
reset to -l.
