### PR TITLE
CTest: Fix missing variable assignment in Coverage InitializeHandler

### DIFF
--- a/Source/CTest/cmCTestCoverageCommand.cxx
+++ b/Source/CTest/cmCTestCoverageCommand.cxx
@@ -25,7 +25,8 @@ cmCTestGenericHandler* cmCTestCoverageCommand::InitializeHandler()
 {
   this->CTest->SetCTestConfigurationFromCMakeVariable(this->Makefile,
     "CoverageCommand", "CTEST_COVERAGE_COMMAND");
-
+  this->CTest->SetCTestConfigurationFromCMakeVariable(this->Makefile,
+    "CoverageExtraFlags", "CTEST_COVERAGE_EXTRA_FLAGS");
   cmCTestCoverageHandler* handler = static_cast<cmCTestCoverageHandler*>(
     this->CTest->GetInitializedHandler("coverage"));
   if ( !handler )


### PR DESCRIPTION
Before, if a script is being used, CTEST_COVERAGE_EXTRA_FLAGS
were not being considered. This should fix this issue.
