### PR TITLE
Improvement to coverage.py source file search algorithm

### DIFF
--- a/Source/CTest/cmParsePythonCoverage.cxx
+++ b/Source/CTest/cmParsePythonCoverage.cxx
@@ -33,19 +33,25 @@ protected:
                      << atts[tagCount+1] << std::endl);
           this->CurFileName = this->Coverage.SourceDir + "/" +
                                  atts[tagCount+1];
-          FileLinesType& curFileLines =
-            this->Coverage.TotalCoverage[this->CurFileName];
           cmsys::ifstream fin(this->CurFileName.c_str());
           if(!fin)
           {
-            cmCTestLog(this->CTest, ERROR_MESSAGE,
-                       "Python Coverage: Error opening " << this->CurFileName
-                       << std::endl);
-            this->Coverage.Error++;
-            break;
+            this->CurFileName = this->Coverage.BinaryDir + "/" +
+                                   atts[tagCount+1];
+            fin.open(this->CurFileName.c_str());
+            if (!fin)
+            {
+              cmCTestLog(this->CTest, ERROR_MESSAGE,
+                         "Python Coverage: Error opening " << this->CurFileName
+                         << std::endl);
+              this->Coverage.Error++;
+              break;
+            }
           }
 
           std::string line;
+          FileLinesType& curFileLines =
+            this->Coverage.TotalCoverage[this->CurFileName];
           curFileLines.push_back(-1);
           while(cmSystemTools::GetLineFromStream(fin, line))
           {


### PR DESCRIPTION
If the coverage.py source file is not found in the source directory, the build
directory is first searched before raising an error.

This is necessary because it is a valid workflow to build a Python package from
source, then install this package to a virtualenv that lives in the build
directory.  Tests will run against this deployed package and therefore the
covered source files will be found in a subdirectory of the build directory, and
not anywhere in the source directory.
