### PR TITLE
Add support for the curses panel library

### DIFF
--- a/Modules/FindCurses.cmake
+++ b/Modules/FindCurses.cmake
@@ -24,7 +24,7 @@
 # NCurses functionality is required.
 
 #=============================================================================
-# Copyright 2001-2009 Kitware, Inc.
+# Copyright 2001-2014 Kitware, Inc.
 #
 # Distributed under the OSI-approved BSD License (the "License");
 # see accompanying file Copyright.txt for details.


### PR DESCRIPTION
Curses usually comes with the addition of a panel library. This just adds support for checking if that library is present in FindCurses.cmake
