### PR TITLE
Coverage results from coverage.py were off by one

### DIFF
--- a/Source/CTest/cmParsePythonCoverage.cxx
+++ b/Source/CTest/cmParsePythonCoverage.cxx
@@ -73,7 +73,7 @@ protected:
           curNumber = atoi(atts[tagCount+1]);
         }
 
-        if(curHits > -1 && curNumber > -1)
+        if(curHits > -1 && curNumber > 0)
         {
           FileLinesType& curFileLines =
             this->Coverage.TotalCoverage[this->CurFileName];


### PR DESCRIPTION
The cobertura format uses line numbers indexed by one, and CTest uses a vector (0-indexed) to store them.
