### PR TITLE
FindGLEW.cmake: add an imported GLEW::GLEW target

### DIFF
--- a/Modules/FindGLEW.cmake
+++ b/Modules/FindGLEW.cmake
@@ -4,6 +4,15 @@
 #
 # Find the OpenGL Extension Wrangler Library (GLEW)
 #
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the :prop_tgt:`IMPORTED` target ``GLEW::GLEW``,
+# if GLEW has been found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
 # This module defines the following variables:
 #
 # ::
@@ -34,5 +43,12 @@ set(GLEW_LIBRARIES ${GLEW_LIBRARY})
 include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
 find_package_handle_standard_args(GLEW
                                   REQUIRED_VARS GLEW_INCLUDE_DIR GLEW_LIBRARY)
+
+if(GLEW_FOUND AND NOT TARGET GLEW::GLEW)
+  add_library(GLEW::GLEW UNKNOWN IMPORTED)
+  set_target_properties(GLEW::GLEW PROPERTIES
+    IMPORTED_LOCATION "${GLEW_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${GLEW_INCLUDE_DIRS}")
+endif()
 
 mark_as_advanced(GLEW_INCLUDE_DIR GLEW_LIBRARY)


### PR DESCRIPTION
Add imported target and documentation for GLEW.
