### PR TITLE
Produce shorter output on no arguments

### DIFF
--- a/Source/CursesDialog/ccmake.cxx
+++ b/Source/CursesDialog/ccmake.cxx
@@ -42,6 +42,17 @@ static const char * cmDocumentationUsage[][2] =
 };
 
 //----------------------------------------------------------------------------
+static const char * cmDocumentationUsageNote[][2] =
+{
+  {0,
+   "Specify a source directory to (re-)generate a build system for it in the "
+   "current working directory.  Specify an existing build directory to "
+   "re-generate its build system.\n"
+   "Run 'ccmake --help' for more information."},
+  {0,0}
+};
+
+//----------------------------------------------------------------------------
 static const char * cmDocumentationOptions[][2] =
 {
   CMAKE_STANDARD_OPTIONS_TABLE,
@@ -102,6 +113,10 @@ int main(int argc, char const* const* argv)
     doc.SetName("ccmake");
     doc.SetSection("Name",cmDocumentationName);
     doc.SetSection("Usage",cmDocumentationUsage);
+    if ( argc == 1 )
+      {
+      doc.AppendSection("Usage",cmDocumentationUsageNote);
+      }
     doc.SetSection("Generators",generators);
     doc.PrependSection("Options",cmDocumentationOptions);
     return doc.PrintRequestedDocumentation(std::cout)? 0:1;

--- a/Source/cmDocumentation.cxx
+++ b/Source/cmDocumentation.cxx
@@ -113,7 +113,9 @@ bool cmDocumentation::PrintDocumentation(Type ht, std::ostream& os)
   switch (ht)
     {
     case cmDocumentation::Usage:
-      return this->PrintDocumentationUsage(os);
+      return this->PrintUsage(os);
+    case cmDocumentation::Help:
+      return this->PrintHelp(os);
     case cmDocumentation::Full:
       return this->PrintHelpFull(os);
     case cmDocumentation::OneManual:
@@ -300,7 +302,7 @@ bool cmDocumentation::CheckOptions(int argc, const char* const* argv,
        (strcmp(argv[i], "-h") == 0) ||
        (strcmp(argv[i], "-H") == 0))
       {
-      help.HelpType = cmDocumentation::Usage;
+      help.HelpType = cmDocumentation::Help;
       GET_OPT_ARGUMENT(help.Argument);
       help.Argument = cmSystemTools::LowerCase(help.Argument);
       // special case for single command
@@ -841,7 +843,19 @@ bool cmDocumentation::PrintHelpListVariables(std::ostream& os)
 }
 
 //----------------------------------------------------------------------------
-bool cmDocumentation::PrintDocumentationUsage(std::ostream& os)
+bool cmDocumentation::PrintUsage(std::ostream& os)
+{
+  std::map<std::string,cmDocumentationSection*>::iterator si;
+  si = this->AllSections.find("Usage");
+  if(si != this->AllSections.end())
+    {
+    this->Formatter.PrintSection(os, *si->second);
+    }
+  return true;
+}
+
+//----------------------------------------------------------------------------
+bool cmDocumentation::PrintHelp(std::ostream& os)
 {
   std::map<std::string,cmDocumentationSection*>::iterator si;
   si = this->AllSections.find("Usage");

--- a/Source/cmDocumentation.h
+++ b/Source/cmDocumentation.h
@@ -102,6 +102,8 @@ private:
   bool PrintFiles(std::ostream& os, std::string const& pattern);
 
   bool PrintVersion(std::ostream& os);
+  bool PrintUsage(std::ostream& os);
+  bool PrintHelp(std::ostream& os);
   bool PrintHelpFull(std::ostream& os);
   bool PrintHelpOneManual(std::ostream& os);
   bool PrintHelpOneCommand(std::ostream& os);
@@ -115,7 +117,6 @@ private:
   bool PrintHelpListProperties(std::ostream& os);
   bool PrintHelpListVariables(std::ostream& os);
   bool PrintHelpListPolicies(std::ostream& os);
-  bool PrintDocumentationUsage(std::ostream& os);
   bool PrintOldCustomModules(std::ostream& os);
 
   const char* GetNameString() const;

--- a/Source/cmDocumentationFormatter.h
+++ b/Source/cmDocumentationFormatter.h
@@ -26,7 +26,7 @@ public:
   /** Types of help provided.  */
   enum Type
   {
-    None, Version, Usage, Full, ListManuals,
+    None, Version, Usage, Help, Full, ListManuals,
     ListCommands, ListModules, ListProperties, ListVariables, ListPolicies,
     OneManual, OneCommand, OneModule, OneProperty, OneVariable, OnePolicy,
     OldCustomModules

--- a/Source/cmakemain.cxx
+++ b/Source/cmakemain.cxx
@@ -45,6 +45,17 @@ static const char * cmDocumentationUsage[][2] =
   {0,0}
 };
 
+//----------------------------------------------------------------------------
+static const char * cmDocumentationUsageNote[][2] =
+{
+  {0,
+   "Specify a source directory to (re-)generate a build system for it in the "
+   "current working directory.  Specify an existing build directory to "
+   "re-generate its build system.\n"
+   "Run 'cmake --help' for more information."},
+  {0,0}
+};
+
 #define CMAKE_BUILD_OPTIONS                                             \
   "  <dir>          = Project binary directory to be built.\n"          \
   "  --target <tgt> = Build <tgt> instead of default targets.\n"        \
@@ -223,6 +234,10 @@ int do_cmake(int ac, char const* const* av)
     doc.SetName("cmake");
     doc.SetSection("Name",cmDocumentationName);
     doc.SetSection("Usage",cmDocumentationUsage);
+    if ( ac == 1 )
+      {
+      doc.AppendSection("Usage",cmDocumentationUsageNote);
+      }
     doc.AppendSection("Generators",generators);
     doc.PrependSection("Options",cmDocumentationOptions);
 


### PR DESCRIPTION
This is accompanying pull request for RFE: http://www.cmake.org/Bug/view.php?id=14973

Instead printing complete help cmake/ccmake now prints only Usage section and
extra information how to get more help or start your build.

Implementation Details:

  Usage help type was renamed to Help, and new Usage was introduces that prints
  only command line usage information without any extra details.

  Commands add some extra information when no arguments are passed.
