### PR TITLE
search for ppc64 in FindJNI on ppc64le as well

### DIFF
--- a/Modules/FindJNI.cmake
+++ b/Modules/FindJNI.cmake
@@ -55,7 +55,7 @@ macro(java_append_library_directories _var)
         # endianess of the underlying system.
         set(_java_libarch "${CMAKE_SYSTEM_PROCESSOR}" "mips" "mipsel" "mipseb")
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64le")
-        set(_java_libarch "ppc64le")
+        set(_java_libarch "ppc64" "ppc64le")
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64")
         set(_java_libarch "ppc64" "ppc")
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)")


### PR DESCRIPTION
IcedTea 2.5 have changed libarch for ppc64le to ppc64. Adjust FindJNI
to look for both for backward compatibility.

Signed-off-by: Dinar Valeev dvaleev@suse.com
