### PR TITLE
Code Blocks/Eclipse: Use non-default stdlib includes when specified.

### DIFF
--- a/Modules/CMakeExtraGeneratorDetermineCompilerMacrosAndIncludeDirs.cmake
+++ b/Modules/CMakeExtraGeneratorDetermineCompilerMacrosAndIncludeDirs.cmake
@@ -30,11 +30,14 @@ macro(_DETERMINE_GCC_SYSTEM_INCLUDE_DIRS _lang _resultIncludeDirs _resultDefines
     if (CMAKE_CXX_FLAGS MATCHES "(-stdlib=[^ ]+)")
       set(_stdlib "${CMAKE_MATCH_1}")
     endif ()
+    if (CMAKE_CXX_FLAGS MATCHES "(-std=[^ ]+)")
+      set(_stdver "${CMAKE_MATCH_1}")
+    endif ()
   else ()
     set(_compilerExecutable "${CMAKE_C_COMPILER}")
     set(_arg1 "${CMAKE_C_COMPILER_ARG1}")
   endif ()
-  execute_process(COMMAND ${_compilerExecutable} ${_arg1} ${_stdlib} -v -E -x ${_lang} -dD dummy
+  execute_process(COMMAND ${_compilerExecutable} ${_arg1} ${_stdver} ${_stdlib} -v -E -x ${_lang} -dD dummy
                   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/CMakeFiles
                   ERROR_VARIABLE _gccOutput
                   OUTPUT_VARIABLE _gccStdout )


### PR DESCRIPTION
When -stdlib=x is specified in CMAKE_CXX_FLAGS this passes it along so
that the correct include dirs are detected.

This allows IDEs to lookup the intended system includes rather than the default stdlib includes for better code-completion, diagnostics, etc.
