### PR TITLE
Add support for a LANGUAGE property “CUDA” to force compilation with nvcc

### DIFF
--- a/Modules/FindCUDA.cmake
+++ b/Modules/FindCUDA.cmake
@@ -1205,7 +1205,10 @@ macro(CUDA_WRAP_SRCS cuda_target format generated_files)
   foreach(file ${ARGN})
     # Ignore any file marked as a HEADER_FILE_ONLY
     get_source_file_property(_is_header ${file} HEADER_FILE_ONLY)
-    if(${file} MATCHES "\\.cu$" AND NOT _is_header)
+    # allow marking of files with the LANGUAGE CUDA propery
+    get_source_file_property(_language_property ${file} LANGUAGE)
+
+    if((${file} MATCHES "\\.cu$" OR ${_language_property} MATCHES "CUDA") AND NOT _is_header)
 
       # Allow per source file overrides of the format.
       get_source_file_property(_cuda_source_format ${file} CUDA_SOURCE_PROPERTY_FORMAT)


### PR DESCRIPTION
This is e.g. needed when compiling applications which actually separate .cu code from .c code, but don't clearly separate e.g. thrust code from no-thrust code. In Mac OSX for example compiling thrust based code with the host compiler will lead to issues, so in such a case allow the user to flag source files as to be compiled with nvcc instead effectively not forcing such limitations on other platforms but only for Mac OSX (because compilation times will explode).
