### PR TITLE
inserted a link to bugtracker into readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,11 @@ For instructions how to do this, see documentation on `Running CMake`_.
 
 .. _`Running CMake`: http://www.cmake.org/cmake/help/runningcmake.html
 
+Reporting bugs
+==============
+
+CMake has a bugtracker at http://www.cmake.org/Bug
+
 Contributing
 ============
 


### PR DESCRIPTION
I found it quite difficult to find a bugtracker for cmake both from repository (where github tracker is not present) as well as cmake.org where link maybe is somewhere, but is not very visible, hopefully this will make it a bit more clear where to report bugs
