### PR TITLE
Ninja generator - fix compilation command getting crazy

### DIFF
--- a/Source/cmNinjaTargetGenerator.cxx
+++ b/Source/cmNinjaTargetGenerator.cxx
@@ -460,9 +460,8 @@ cmNinjaTargetGenerator
        i != compileCmds.end(); ++i)
     this->GetLocalGenerator()->ExpandRuleVariables(*i, vars);
 
-  std::string cmdLine =
-    this->GetLocalGenerator()->BuildCommandLine(compileCmds);
-
+  std::string cmdLine = "cmd.exe /C \"" + 
+    this->GetLocalGenerator()->BuildCommandLine(compileCmds) + " \"";
 
   // Write the rule for compiling file of the given language.
   cmOStringStream comment;


### PR DESCRIPTION
when trying to use an unsupported compiler (CodeWarrior for Wii), it tries to access a licensing file for each compilation unity, it seems that it does not know how to behave when running in parallel. This fix the problem, I do not know if this causes any other impact, but I don't think so.
