### PR TITLE
ExternalProject: fix retry logic

### DIFF
--- a/Modules/ExternalProject.cmake
+++ b/Modules/ExternalProject.cmake
@@ -668,7 +668,6 @@ file(DOWNLOAD
   \"${remote}\"
   \"${local}\"
   ${show_progress}
-  ${hash_args}
   ${timeout_args}
   STATUS status
   LOG log)


### PR DESCRIPTION
Do not check file's hash in download script. If hash will not match
command `file(DOWNLOAD ...)` will fail with FATAL_ERROR, hence `cmake -P`
will exit with unsuccessful code and build will stop. Leave hash checking to
verify step.
