### PR TITLE
Adjust expected error message in FailedSubmit-ftp

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2609,7 +2609,7 @@ ${CMake_BINARY_DIR}/bin/cmake -DDIR=dev -P ${CMake_SOURCE_DIR}/Utilities/Release
   set(regex "${regex}|Error message was: ")
   set(regex "${regex}([Cc]ould *n.t resolve host")
   set(regex "${regex}|[Cc]ould *n.t connect to host")
-  set(regex "${regex}|Failed connect to")
+  set(regex "${regex}|Failed *t*o* connect to")
   set(regex "${regex}|Empty reply from server")
   set(regex "${regex}|The requested URL returned error")
   set(regex "${regex}|libcurl was built with SSL disabled. https: not supported)")


### PR DESCRIPTION
Error message from cygwin's curl (using `../bootstrap --system-libs` or `cmake .. -DCMAKE_USE_SYSTEM_LIBRARIES=ON`, then `ctest -V -R ftp` in cygwin) in CTestTestFailedSubmit-ftp was:
`Failed to connect to  port 21: Connection timed out`, causing this test to fail. Slight extension of this expected error message regex catches this version.
