### PR TITLE
Initializing CurFileName to an empty string

### DIFF
--- a/Source/CTest/cmParseCoberturaCoverage.cxx
+++ b/Source/CTest/cmParseCoberturaCoverage.cxx
@@ -71,6 +71,7 @@ protected:
           cmCTestLog(this->CTest, HANDLER_VERBOSE_OUTPUT, "Reading file: "
                      << atts[tagCount+1]<< std::endl);
           std::string filename = atts[tagCount+1];
+          this->CurFileName = "";
           for(size_t i=0;i < FilePaths.size();i++)
             {
             finalpath = FilePaths[i] + "/" + filename;


### PR DESCRIPTION
When the file is not found in `$CMAKE_SOURCE_DIR/<file path>`, the `CurFileName` pointer remained set to the previous file.  This caused the new file's coverage data to populate the into the wrong object giving incorrect results and occasionally resulting in a seg fault.
