### PR TITLE
Update documentation to use working configure_file command signature from COPY_ONLY to documented COPYONLY

### DIFF
--- a/Help/manual/cmake-packages.7.rst
+++ b/Help/manual/cmake-packages.7.rst
@@ -316,7 +316,7 @@ shared library:
   )
   configure_file(cmake/ClimbingStatsConfig.cmake
     "${CMAKE_CURRENT_BINARY_DIR}/ClimbingStats/ClimbingStatsConfig.cmake"
-    COPY_ONLY
+    COPYONLY
   )
 
   set(ConfigPackageLocation lib/cmake/ClimbingStats)


### PR DESCRIPTION
I believe the configure_file signature requires COPYONLY (no underscore).  http://www.cmake.org/cmake/help/v3.0/command/configure_file.html

Surprised I did not get an error before the change, which would have been helpful in debugging.
