### PR TITLE
AIX 5.1: Test whether _SC_AIX_REALMEM is available

### DIFF
--- a/Source/kwsys/SystemInformation.cxx
+++ b/Source/kwsys/SystemInformation.cxx
@@ -3913,7 +3913,7 @@ bool SystemInformationImplementation::QueryCygwinMemory()
 
 bool SystemInformationImplementation::QueryAIXMemory()
 {
-#if defined(_AIX)
+#if defined(_AIX) && defined(_SC_AIX_REALMEM)
   long c = sysconf(_SC_AIX_REALMEM);
   if (c <= 0)
     {


### PR DESCRIPTION
The _SC_AIX_REALMEM is not available on AIX 5.1
