### PR TITLE
FindUnixCommand indicates status

### DIFF
--- a/Modules/FindUnixCommands.cmake
+++ b/Modules/FindUnixCommands.cmake
@@ -2,12 +2,13 @@
 # FindUnixCommands
 # ----------------
 #
-# Find unix commands from cygwin
+# Find Unix commands, including the ones from Cygwin
 #
-# This module looks for some usual Unix commands.
+# This module looks for the Unix commands bash, cp, gzip, mv, rm, and tar
+# and stores the result in the variables BASH, CP, GZIP, MV, RM, and TAR.
 
 #=============================================================================
-# Copyright 2001-2009 Kitware, Inc.
+# Copyright 2001-2014 Kitware, Inc.
 #
 # Distributed under the OSI-approved BSD License (the "License");
 # see accompanying file Copyright.txt for details.
@@ -19,7 +20,7 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-include(${CMAKE_CURRENT_LIST_DIR}/FindCygwin.cmake)
+include(FindCygwin)
 
 find_program(BASH
   bash
@@ -94,4 +95,9 @@ find_program(TAR
 )
 mark_as_advanced(
   TAR
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(UnixCommands
+  REQUIRED_VARS BASH CP GZIP MV RM TAR
 )


### PR DESCRIPTION
Otherwise the UnixCommands were marked as not found in the summary.
Additionally the documentation was extended.
