### PR TITLE
Add xterm-termite to VT100 color support whitelist

### DIFF
--- a/Source/kwsys/Terminal.c
+++ b/Source/kwsys/Terminal.c
@@ -175,6 +175,7 @@ static const char* kwsysTerminalVT100Names[] =
   "xterm-88color",
   "xterm-color",
   "xterm-debian",
+  "xterm-termite",
   0
 };
 


### PR DESCRIPTION
Justs adds `xterm-termite` to the list of terminals with color support.

In reponse to a issue received on [termite's issue tracker](https://github.com/thestinger/termite/issues/207).