### PR TITLE
Don't set OPENSSL_VERSION to _OPENSSL_VERSION

### DIFF
--- a/Modules/FindOpenSSL.cmake
+++ b/Modules/FindOpenSSL.cmake
@@ -283,9 +283,7 @@ function(from_hex HEX DEC)
 endfunction()
 
 if (OPENSSL_INCLUDE_DIR)
-  if (_OPENSSL_VERSION)
-    set(OPENSSL_VERSION "${_OPENSSL_VERSION}")
-  elseif(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+  if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
     file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
          REGEX "^#define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
 


### PR DESCRIPTION
[Casablanca](https://casablanca.codeplex.com/) is a project that uses CMake as it's build tool. On OS X, it tries to prefer the OpenSSL version found from Homebrew over the system-supplied one with the following CMake snippet:

```
  if(APPLE AND NOT OPENSSL_ROOT_DIR)
    # Prefer a homebrew version of OpenSSL over the one in /usr/lib
    file(GLOB OPENSSL_ROOT_DIR /usr/local/Cellar/openssl/*)
    # Prefer the latest (make the latest one first)
    list(REVERSE OPENSSL_ROOT_DIR)
  endif()
  # This should prevent linking against the system provided 0.9.8y
  find_package(OpenSSL 1.0.0 REQUIRED)
```

However, this fails due to FindOpenSSL module blindly setting OPENSSL_VERSION to _OPENSSL_VERSION, even when OPENSSL_INCLUDE_DIR at that point already points to the Homebrew-supplied version.

(Workaround for previous versions of CMake is to set _OPENSSL_VERSION to "" just before `find_package`.)