### PR TITLE
Add support for XAML and RESW files in Visual Studio 2010+ generators.

### DIFF
--- a/Source/cmGeneratorTarget.cxx
+++ b/Source/cmGeneratorTarget.cxx
@@ -53,6 +53,7 @@ struct ExternalObjectsTag {};
 struct IDLSourcesTag {};
 struct ResxTag {};
 struct XamlTag {};
+struct ReswTag {};
 struct ModuleDefinitionFileTag {};
 struct AppManifestTag{};
 struct CertificatesTag{};
@@ -111,6 +112,10 @@ struct DoAccept<true>
     std::string hSourceFileName = xaml + ".cpp";
     data.ExpectedXamlSources.insert(hSourceFileName);
     data.XamlSources.push_back(f);
+    }
+  static void Do(cmGeneratorTarget::ReswData& data, cmSourceFile* f)
+    {
+    data.ReswResources.push_back(f);
     }
   static void Do(std::string& data, cmSourceFile* f)
     {
@@ -195,6 +200,10 @@ struct TagVisitor
     else if(ext == "xaml")
       {
       DoAccept<IsSameTag<Tag, XamlTag>::Result>::Do(this->Data, sf);
+      }
+    else if(ext == "resw")
+      {
+      DoAccept<IsSameTag<Tag, ReswTag>::Result>::Do(this->Data, sf);
       }
     else if (ext == "appxmanifest")
       {
@@ -465,6 +474,16 @@ void cmGeneratorTarget
   XamlData data;
   IMPLEMENT_VISIT_IMPL(Xaml, COMMA cmGeneratorTarget::XamlData)
   srcs = data.XamlSources;
+}
+
+//----------------------------------------------------------------------------
+void cmGeneratorTarget
+::GetReswSources(std::vector<cmSourceFile const*>& srcs,
+                 const std::string& config) const
+{
+  ReswData data;
+  IMPLEMENT_VISIT_IMPL(Resw, COMMA cmGeneratorTarget::ReswData)
+  srcs = data.ReswResources;
 }
 
 //----------------------------------------------------------------------------

--- a/Source/cmGeneratorTarget.h
+++ b/Source/cmGeneratorTarget.h
@@ -42,6 +42,8 @@ public:
 
   void GetResxSources(std::vector<cmSourceFile const*>&,
                       const std::string& config) const;
+  void GetXamlSources(std::vector<cmSourceFile const*>&,
+                      const std::string& config) const;
   void GetIDLSources(std::vector<cmSourceFile const*>&,
                      const std::string& config) const;
   void GetExternalObjects(std::vector<cmSourceFile const*>&,
@@ -53,6 +55,10 @@ public:
   void GetCustomCommands(std::vector<cmSourceFile const*>&,
                          const std::string& config) const;
   void GetExpectedResxHeaders(std::set<std::string>&,
+                              const std::string& config) const;
+  void GetExpectedXamlHeaders(std::set<std::string>&,
+                              const std::string& config) const;
+  void GetExpectedXamlSources(std::set<std::string>&,
                               const std::string& config) const;
   void GetAppManifest(std::vector<cmSourceFile const*>&,
                       const std::string& config) const;
@@ -131,6 +137,12 @@ public:
   struct ResxData {
     mutable std::set<std::string> ExpectedResxHeaders;
     mutable std::vector<cmSourceFile const*> ResxSources;
+  };
+
+  struct XamlData {
+    mutable std::set<std::string> ExpectedXamlHeaders;
+    mutable std::set<std::string> ExpectedXamlSources;
+    mutable std::vector<cmSourceFile const*> XamlSources;
   };
 private:
   friend class cmTargetTraceDependencies;

--- a/Source/cmGeneratorTarget.h
+++ b/Source/cmGeneratorTarget.h
@@ -44,6 +44,8 @@ public:
                       const std::string& config) const;
   void GetXamlSources(std::vector<cmSourceFile const*>&,
                       const std::string& config) const;
+  void GetReswSources(std::vector<cmSourceFile const*>&,
+                      const std::string& config) const;
   void GetIDLSources(std::vector<cmSourceFile const*>&,
                      const std::string& config) const;
   void GetExternalObjects(std::vector<cmSourceFile const*>&,
@@ -143,6 +145,10 @@ public:
     mutable std::set<std::string> ExpectedXamlHeaders;
     mutable std::set<std::string> ExpectedXamlSources;
     mutable std::vector<cmSourceFile const*> XamlSources;
+  };
+
+  struct ReswData {
+    mutable std::vector<cmSourceFile const*> ReswResources;
   };
 private:
   friend class cmTargetTraceDependencies;

--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -462,6 +462,7 @@ void cmVisualStudio10TargetGenerator::Generate()
   this->WriteDotNetReferences();
   this->WriteEmbeddedResourceGroup();
   this->WriteXamlGroup();
+  this->WriteReswGroup();
   this->WriteWinRTReferences();
   this->WriteProjectReferences();
   this->WriteString(
@@ -575,6 +576,23 @@ void cmVisualStudio10TargetGenerator::WriteXamlGroup()
 
       this->WriteString("</", 2);
       (*this->BuildFileStream ) << tool << ">\n";
+      }
+    this->WriteString("</ItemGroup>\n", 1);
+    }
+}
+
+void cmVisualStudio10TargetGenerator::WriteReswGroup()
+{
+  std::vector<cmSourceFile const*> reswObjs;
+    this->GeneratorTarget->GetReswSources(reswObjs, "");
+  if(!reswObjs.empty())
+    {
+    this->WriteString("<ItemGroup>\n", 1);
+    for(std::vector<cmSourceFile const*>::const_iterator oi = reswObjs.begin();
+        oi != reswObjs.end(); ++oi)
+      {
+      std::string obj = (*oi)->GetFullPath();
+      this->WriteSource("PRIResource", *oi);
       }
     this->WriteString("</ItemGroup>\n", 1);
     }

--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -524,7 +524,7 @@ void cmVisualStudio10TargetGenerator::WriteEmbeddedResourceGroup()
       this->WriteString("<DependentUpon>", 3);
       std::string hFileName = obj.substr(0, obj.find_last_of(".")) + ".h";
       (*this->BuildFileStream ) << hFileName;
-      this->WriteString("</DependentUpon>\n", 3);
+      this->WriteString("</DependentUpon>\n", 0);
 
       std::vector<std::string> const * configs =
         this->GlobalGenerator->GetConfigurations();

--- a/Source/cmVisualStudio10TargetGenerator.h
+++ b/Source/cmVisualStudio10TargetGenerator.h
@@ -68,6 +68,7 @@ private:
   void WriteDotNetReferences();
   void WriteEmbeddedResourceGroup();
   void WriteXamlGroup();
+  void WriteReswGroup();
   void WriteWinRTReferences();
   void WriteWinRTPackageCertificateKeyFile();
   void WritePathAndIncrementalLinkOptions();

--- a/Source/cmVisualStudio10TargetGenerator.h
+++ b/Source/cmVisualStudio10TargetGenerator.h
@@ -61,12 +61,13 @@ private:
   void WriteExtraSource(cmSourceFile const* sf);
   void WriteNsightTegraConfigurationValues(std::string const& config);
   void WriteSource(std::string const& tool, cmSourceFile const* sf,
-                   const char* end = 0);
+                   const char* end = 0, bool relative = false);
   void WriteSources(std::string const& tool,
                     std::vector<cmSourceFile const*> const&);
   void WriteAllSources();
   void WriteDotNetReferences();
   void WriteEmbeddedResourceGroup();
+  void WriteXamlGroup();
   void WriteWinRTReferences();
   void WriteWinRTPackageCertificateKeyFile();
   void WritePathAndIncrementalLinkOptions();
@@ -119,6 +120,8 @@ private:
   void AddMissingSourceGroups(std::set<cmSourceGroup*>& groupsUsed,
                               const std::vector<cmSourceGroup>& allGroups);
   bool IsResxHeader(const std::string& headerFile);
+  bool IsXamlHeader(const std::string& headerFile);
+  bool IsXamlSource(const std::string& sourceFile);
 
   cmIDEFlagTable const* GetClFlagTable() const;
   cmIDEFlagTable const* GetRcFlagTable() const;


### PR DESCRIPTION
Add support for XAML files to Visual Studio 2010+ generatos. Xaml files
are added as Page or ApplicationDefinition if VS_APPLICATION_DEFINITION
property is set.

NOTE: New source file property VS_APPLICATION_DEFINITION.

Add support for RESW files to Visual Studio 2010+ generatos. Resw files
are added as PRIResource element.

Do not add extra spaces in single line before closing DependentUpon tag. Doing so will
result in compilation error.