### PR TITLE
PROTOBUF_GENERATE_CPP: fix generated paths

### DIFF
--- a/Modules/FindProtobuf.cmake
+++ b/Modules/FindProtobuf.cmake
@@ -127,13 +127,14 @@ function(PROTOBUF_GENERATE_CPP SRCS HDRS)
   foreach(FIL ${ARGN})
     get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
     get_filename_component(FIL_WE ${FIL} NAME_WE)
+    get_filename_component(DIR ${FIL} DIRECTORY)
 
-    list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc")
-    list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h")
+    list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${DIR}/${FIL_WE}.pb.cc")
+    list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${DIR}/${FIL_WE}.pb.h")
 
     add_custom_command(
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc"
-             "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h"
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${DIR}/${FIL_WE}.pb.cc"
+             "${CMAKE_CURRENT_BINARY_DIR}/${DIR}/${FIL_WE}.pb.h"
       COMMAND  ${PROTOBUF_PROTOC_EXECUTABLE}
       ARGS --cpp_out  ${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
       DEPENDS ${ABS_FIL} ${PROTOBUF_PROTOC_EXECUTABLE}


### PR DESCRIPTION
The "problem" here is when you place your `*.proto` files inside a subdirectory, e.g. `proto`.
The call to `protoc` will create the subdirectory `proto` inside of `CMAKE_CURRENT_BINARY_DIR`, so the resulting path is something like `${CMAKE_CURRENT_BINARY_DIR}/proto/example.pb.*` but the function will add `${CMAKE_CURRENT_BINARY_DIR}/example.pb.*` to the lists.

So, if you have multiple `*.proto` files with the same name in different directories, this might be a problem because the same path would be added to the list.

I am not 100% sure if this is really a problem or if it would simply result in regenerating the source files with each build even if it is not necessary.