### PR TITLE
Set Xcode file type for Metal shader files

### DIFF
--- a/Source/cmGlobalXCodeGenerator.cxx
+++ b/Source/cmGlobalXCodeGenerator.cxx
@@ -865,6 +865,10 @@ GetSourcecodeValueFromFileExtension(const std::string& _ext,
     {
     sourcecode += ".asm";
     }
+  else if (ext == "metal")
+    {
+    sourcecode += ".metal";
+    }
   //else
   //  {
   //  // Already specialized above or we leave sourcecode == "sourcecode"


### PR DESCRIPTION
Sets the Xcode file type to "sourcecode.metal". Xcode can then compile and embed Metal shaders into applications. Note that Metal shaders need to be listed as Resources, i.e.:

set_target_properties(test_ios PROPERTIES RESOURCE ../content/shaders/shaders.metal)