### PR TITLE
QMacInstallDialog: Use Authorization Services to install command line to...

### DIFF
--- a/Source/QtDialog/QMacInstallDialog.cxx
+++ b/Source/QtDialog/QMacInstallDialog.cxx
@@ -34,94 +34,43 @@ QMacInstallDialog::~QMacInstallDialog()
 
 void QMacInstallDialog::DoInstall()
 {
-  OSStatus myStatus;
-
-	AuthorizationFlags myFlags = kAuthorizationFlagDefaults;
-  AuthorizationRef myAuthorizationRef;
-  myStatus = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment,
-                                 myFlags, &myAuthorizationRef);
-  if (myStatus != errAuthorizationSuccess) return;
-  
-  AuthorizationItem myItems = {kAuthorizationRightExecute, 0,
-	                                 NULL, 0};
-	AuthorizationRights myRights = {1, &myItems};
-	myFlags = kAuthorizationFlagDefaults |
-	          kAuthorizationFlagInteractionAllowed |
-	          kAuthorizationFlagPreAuthorize |
-	          kAuthorizationFlagExtendRights;
-	myStatus =
-	      AuthorizationCopyRights(myAuthorizationRef,&myRights,NULL,myFlags,NULL);
-	  
-	if (myStatus == errAuthorizationSuccess)
-  {
-    QDir installDir(this->Internals->InstallPrefix->text());
-    QString installTo = installDir.path();
-    if(!cmSystemTools::FileExists(installTo.toLocal8Bit().data()))
+  std::string cmd;
+  QDir installDir(this->Internals->InstallPrefix->text());
+  QString installTo = installDir.path();
+  if(!cmSystemTools::FileExists(installTo.toLocal8Bit().data()))
+    {
+    QString message = tr("Build install does not exist, "
+                         "should I create it?\n\n"
+                         "Directory: ");
+    message += installDir.path();
+    QString title = tr("Create Directory");
+    QMessageBox::StandardButton btn;
+    btn = QMessageBox::information(this, title, message,
+                                   QMessageBox::Yes | QMessageBox::No);
+    if(btn == QMessageBox::Yes)
       {
-      QString message = tr("Build install does not exist, "
-                           "should I create it?\n\n"
-                           "Directory: ");
-      message += installDir.path();
-      QString title = tr("Create Directory");
-      QMessageBox::StandardButton btn;
-      btn = QMessageBox::information(this, title, message,
-                                     QMessageBox::Yes | QMessageBox::No);
-      if(btn == QMessageBox::Yes)
-        {
-        cmSystemTools::MakeDirectory(installTo.toLocal8Bit().data());
-        }
+      cmSystemTools::MakeDirectory(installTo.toLocal8Bit().data());
       }
-    QDir cmExecDir(QApplication::applicationDirPath());
-    cmExecDir.cd("../bin");
-    QFileInfoList list = cmExecDir.entryInfoList();
-    char *args[list.size() + 3];
-    int myArgc = 0;
-    args[myArgc] = new char[4];
-    strcpy(args[myArgc++],"-sfh");
-    for (int i = 0; i < list.size(); ++i)
-      {
-      QFileInfo fileInfo = list.at(i);
-      QString filename = fileInfo.fileName();
-      if(filename.size() && filename[0] == '.')
-        {
-        continue;
-        }
-      QString file = fileInfo.absoluteFilePath();
-      
-      args[myArgc] = new char[file.toLocal8Bit().size()+1];
-      strcpy(args[myArgc++] , file.toLocal8Bit().data());        
-                 
-      }
-    args[myArgc] = new char[installTo.toLocal8Bit().size()+1];  
-    args[myArgc++] = installTo.toLocal8Bit().data();
-    args[myArgc] = NULL;
-    std::cout << "ln";
-    for (int j = 0; j < myArgc; j++) {
-      std::cout << " " << args[j];
     }
-    std::cout << "\n";
-    myFlags = kAuthorizationFlagDefaults;
-    
-// AuthorizationExecuteWithPrivileges is deprecated 
-// see the following link for an alternative that requires code signing
-// https://bitbucket.org/sinbad/privilegedhelperexample  
-  	myStatus = AuthorizationExecuteWithPrivileges (myAuthorizationRef, 
-       "/bin/ln", myFlags, args,  NULL);
-    if(myStatus != errAuthorizationSuccess)
+  QDir cmExecDir(QApplication::applicationDirPath());
+  cmExecDir.cd("../bin");
+  QFileInfoList list = cmExecDir.entryInfoList();
+  cmd.append("osascript -e 'do shell script \"ln -sfh ");
+  for (int i = 0; i < list.size(); ++i)
+    {
+    QFileInfo fileInfo = list.at(i);
+    QString filename = fileInfo.fileName();
+    if(filename.size() && filename[0] == '.')
       {
-      QString message = tr("Failed create symlinks");
-      QString title = tr("Error Creating Symlink");
-      QMessageBox::StandardButton btn =
-        QMessageBox::critical(this, title, message,
-                              QMessageBox::Ok|QMessageBox::Abort);
-      if(btn == QMessageBox::Abort)
-        {
-        return;
-        }
+      continue;
       }
-           
-    AuthorizationFree (myAuthorizationRef, kAuthorizationFlagDefaults);
-  }
+    QString file = fileInfo.absoluteFilePath();
+    cmd.append("\\\"").append(file.toLocal8Bit().data()).append("\\\" ");
+    }
+    cmd.append("\\\"").append(installTo.toLocal8Bit().data()).append("\\\" ");
+    cmd.append("\" with administrator privileges'");
+    std::cout << cmd << "\n";
+    system(cmd.c_str());
 
   this->done(0);
 }

--- a/Source/QtDialog/QMacInstallDialog.cxx
+++ b/Source/QtDialog/QMacInstallDialog.cxx
@@ -4,8 +4,6 @@
 #include <iostream>
 #include <QFileDialog>
 #include "ui_MacInstallDialog.h"
-#include <Security/Authorization.h>
-#include <Security/AuthorizationTags.h>
 
 class QMacInstallDialog::QMacInstallDialogInternals : public Ui::Dialog
 {

--- a/Source/QtDialog/QMacInstallDialog.cxx
+++ b/Source/QtDialog/QMacInstallDialog.cxx
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <QFileDialog>
 #include "ui_MacInstallDialog.h"
+#include <Security/Authorization.h>
+#include <Security/AuthorizationTags.h>
 
 class QMacInstallDialog::QMacInstallDialogInternals : public Ui::Dialog
 {
@@ -32,65 +34,82 @@ QMacInstallDialog::~QMacInstallDialog()
 
 void QMacInstallDialog::DoInstall()
 {
-  QDir installDir(this->Internals->InstallPrefix->text());
-  QString installTo = installDir.path();
-  if(!cmSystemTools::FileExists(installTo.toLocal8Bit().data()))
-    {
-    QString message = tr("Build install does not exist, "
-                         "should I create it?\n\n"
-                         "Directory: ");
-    message += installDir.path();
-    QString title = tr("Create Directory");
-    QMessageBox::StandardButton btn;
-    btn = QMessageBox::information(this, title, message,
-                                   QMessageBox::Yes | QMessageBox::No);
-    if(btn == QMessageBox::Yes)
+  OSStatus myStatus;
+
+	AuthorizationFlags myFlags = kAuthorizationFlagDefaults;
+  AuthorizationRef myAuthorizationRef;
+  myStatus = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment,
+                                 myFlags, &myAuthorizationRef);
+  if (myStatus != errAuthorizationSuccess) return;
+  
+  AuthorizationItem myItems = {kAuthorizationRightExecute, 0,
+	                                 NULL, 0};
+	AuthorizationRights myRights = {1, &myItems};
+	myFlags = kAuthorizationFlagDefaults |
+	          kAuthorizationFlagInteractionAllowed |
+	          kAuthorizationFlagPreAuthorize |
+	          kAuthorizationFlagExtendRights;
+	myStatus =
+	      AuthorizationCopyRights(myAuthorizationRef,&myRights,NULL,myFlags,NULL);
+	  
+	if (myStatus == errAuthorizationSuccess)
+  {
+    QDir installDir(this->Internals->InstallPrefix->text());
+    QString installTo = installDir.path();
+    if(!cmSystemTools::FileExists(installTo.toLocal8Bit().data()))
       {
-      cmSystemTools::MakeDirectory(installTo.toLocal8Bit().data());
-      }
-    }
-  QDir cmExecDir(QApplication::applicationDirPath());
-  cmExecDir.cd("../bin");
-  QFileInfoList list = cmExecDir.entryInfoList();
-  for (int i = 0; i < list.size(); ++i)
-    {
-    QFileInfo fileInfo = list.at(i);
-    QString filename = fileInfo.fileName();
-    if(filename.size() && filename[0] == '.')
-      {
-      continue;
-      }
-    QString file = fileInfo.absoluteFilePath();
-    QString newName = installTo;
-    newName += "/";
-    newName += filename;
-    // Remove the old files
-    if(cmSystemTools::FileExists(newName.toLocal8Bit().data()))
-      {
-      std::cout << "rm [" << newName.toLocal8Bit().data() << "]\n";
-      if(!cmSystemTools::RemoveFile(newName.toLocal8Bit().data()))
+      QString message = tr("Build install does not exist, "
+                           "should I create it?\n\n"
+                           "Directory: ");
+      message += installDir.path();
+      QString title = tr("Create Directory");
+      QMessageBox::StandardButton btn;
+      btn = QMessageBox::information(this, title, message,
+                                     QMessageBox::Yes | QMessageBox::No);
+      if(btn == QMessageBox::Yes)
         {
-        QString message = tr("Failed to remove file "
-                             "installation may be incomplete: ");
-        message += newName;
-        QString title = tr("Error Removing file");
-        QMessageBox::StandardButton btn =
-          QMessageBox::critical(this, title, message,
-                                QMessageBox::Ok|QMessageBox::Abort);
-        if(btn == QMessageBox::Abort)
-          {
-          return;
-          }
+        cmSystemTools::MakeDirectory(installTo.toLocal8Bit().data());
         }
       }
-    std::cout << "ln -s [" << file.toLocal8Bit().data() << "] [";
-    std::cout << newName.toLocal8Bit().data() << "]\n";
-    if(!cmSystemTools::CreateSymlink(file.toLocal8Bit().data(),
-                                     newName.toLocal8Bit().data()))
+    QDir cmExecDir(QApplication::applicationDirPath());
+    cmExecDir.cd("../bin");
+    QFileInfoList list = cmExecDir.entryInfoList();
+    char *args[list.size() + 3];
+    int myArgc = 0;
+    args[myArgc] = new char[4];
+    strcpy(args[myArgc++],"-sfh");
+    for (int i = 0; i < list.size(); ++i)
       {
-      QString message = tr("Failed create symlink "
-                           "installation may be incomplete: ");
-      message += newName;
+      QFileInfo fileInfo = list.at(i);
+      QString filename = fileInfo.fileName();
+      if(filename.size() && filename[0] == '.')
+        {
+        continue;
+        }
+      QString file = fileInfo.absoluteFilePath();
+      
+      args[myArgc] = new char[file.toLocal8Bit().size()+1];
+      strcpy(args[myArgc++] , file.toLocal8Bit().data());        
+                 
+      }
+    args[myArgc] = new char[installTo.toLocal8Bit().size()+1];  
+    args[myArgc++] = installTo.toLocal8Bit().data();
+    args[myArgc] = NULL;
+    std::cout << "ln";
+    for (int j = 0; j < myArgc; j++) {
+      std::cout << " " << args[j];
+    }
+    std::cout << "\n";
+    myFlags = kAuthorizationFlagDefaults;
+    
+// AuthorizationExecuteWithPrivileges is deprecated 
+// see the following link for an alternative that requires code signing
+// https://bitbucket.org/sinbad/privilegedhelperexample  
+  	myStatus = AuthorizationExecuteWithPrivileges (myAuthorizationRef, 
+       "/bin/ln", myFlags, args,  NULL);
+    if(myStatus != errAuthorizationSuccess)
+      {
+      QString message = tr("Failed create symlinks");
       QString title = tr("Error Creating Symlink");
       QMessageBox::StandardButton btn =
         QMessageBox::critical(this, title, message,
@@ -100,7 +119,10 @@ void QMacInstallDialog::DoInstall()
         return;
         }
       }
-    }
+           
+    AuthorizationFree (myAuthorizationRef, kAuthorizationFlagDefaults);
+  }
+
   this->done(0);
 }
 


### PR DESCRIPTION
Use authorization services to install commad line tool symlinks on OSX.
related to bug http://public.kitware.com/Bug/print_bug_page.php?bug_id=10056
http://stackoverflow.com/questions/23849962/cmake-installer-for-mac-fails-to-create-usr-bin-symlinks
