### PR TITLE
Compact dependency graph

### DIFF
--- a/Modules/CMakeGraphVizOptions.cmake
+++ b/Modules/CMakeGraphVizOptions.cmake
@@ -110,19 +110,17 @@
 #
 # .. variable:: GRAPHVIZ_NODE_FILTER
 #
-#  A list of regular replace expressions for chnging the name of nodes.
+#  A list of regular replace expressions for chnging the name of external library nodes.
+#  They are organized in pairs of regex and replace expression.
 #  This can be used to strip the path from external library names,
 #  or normalize the name of different files from the same library to one common name.
+#  The following is an example of an expression pair to strip the path and group by
+#  library name such as "boost" or "sigc" : 
+#  "([A-Z]:)?/([^/]+/)*lib([A-Za-z]+).*\\.(lib|so|dll)" "$3"
 #
 #  * Mandatory : NO
 #  * Default   : 
 #
-# .. variable:: GRAPHVIZ_NODE_GROUP
-#
-#  Set this to TRUE to group all nodes with the same name into one common node.
-#
-#  * Mandatory : NO
-#  * Default   : FALSE
 
 #=============================================================================
 # Copyright 2007-2009 Kitware, Inc.

--- a/Modules/CMakeGraphVizOptions.cmake
+++ b/Modules/CMakeGraphVizOptions.cmake
@@ -116,7 +116,7 @@
 #  or normalize the name of different files from the same library to one common name.
 #  The following is an example of an expression pair to strip the path and group by
 #  library name such as "boost" or "sigc" : 
-#  "([A-Z]:)?/([^/]+/)*lib([A-Za-z]+).*\\.(lib|so|dll)" "$3"
+#  "([A-Z]:)?/([^/]+/)*lib([A-Za-z]+).*\\.(lib|so|dll)" "\\3"
 #
 #  * Mandatory : NO
 #  * Default   : 

--- a/Modules/CMakeGraphVizOptions.cmake
+++ b/Modules/CMakeGraphVizOptions.cmake
@@ -107,6 +107,22 @@
 #
 #  * Mandatory : NO
 #  * Default   : TRUE
+#
+# .. variable:: GRAPHVIZ_NODE_FILTER
+#
+#  A list of regular replace expressions for chnging the name of nodes.
+#  This can be used to strip the path from external library names,
+#  or normalize the name of different files from the same library to one common name.
+#
+#  * Mandatory : NO
+#  * Default   : 
+#
+# .. variable:: GRAPHVIZ_NODE_GROUP
+#
+#  Set this to TRUE to group all nodes with the same name into one common node.
+#
+#  * Mandatory : NO
+#  * Default   : FALSE
 
 #=============================================================================
 # Copyright 2007-2009 Kitware, Inc.

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -45,8 +45,6 @@ endif()
 
 set(EXECUTABLE_OUTPUT_PATH ${CMake_BIN_DIR})
 
-add_definitions(-std=c++11)
-
 # ensure Unicode friendly APIs are used on Windows
 if(WIN32)
   add_definitions(-DUNICODE -D_UNICODE)
@@ -321,6 +319,8 @@ set(SRCS
   cmPropertyMap.h
   cmQtAutoGenerators.cxx
   cmQtAutoGenerators.h
+  cmRegexTools.h
+  cmRegexTools.cxx
   cmRST.cxx
   cmRST.h
   cmScriptGenerator.h

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -45,6 +45,8 @@ endif()
 
 set(EXECUTABLE_OUTPUT_PATH ${CMake_BIN_DIR})
 
+add_definitions(-std=c++11)
+
 # ensure Unicode friendly APIs are used on Windows
 if(WIN32)
   add_definitions(-DUNICODE -D_UNICODE)

--- a/Source/cmGraphVizWriter.cxx
+++ b/Source/cmGraphVizWriter.cxx
@@ -14,6 +14,7 @@
 #include "cmLocalGenerator.h"
 #include "cmGlobalGenerator.h"
 #include "cmGeneratedFileStream.h"
+#include "cmRegexTools.h"
 
 
 
@@ -164,18 +165,8 @@ void cmGraphVizWriter::ReadSettings(const char* settingsFileName,
       {
       const std::string currentRegexString(*itvIt);
       const std::string currentReplaceString(*++itvIt);
-      try
-        {
-        std::regex currentRegex(currentRegexString, std::regex::extended);
-        this->GraphNodeNameFilters.push_back(
-            std::make_pair(currentRegex, currentReplaceString));
-        }
-      catch(std::regex_error& e)
-        {
-        std::cerr << "Could not compile bad regex \"" << currentRegexString
-                  << "\"" << std::endl
-                  << e.what() << std::endl;
-        }
+      this->GraphNodeNameFilters.push_back(
+            std::make_pair(currentRegexString, currentReplaceString));
 
       if(itvIt == nodeNameFilterRegExVector.end())
          break;
@@ -625,11 +616,10 @@ bool cmGraphVizWriter::IgnoreThisTarget(const std::string& name)
 
 std::string cmGraphVizWriter::MangleNodeName(std::string name) const
 {
-  for(const auto& replacer : this->GraphNodeNameFilters)
-    if(std::regex_search(name, replacer.first))
-      {
-      name = std::regex_replace(name, replacer.first, replacer.second); 
-      }
+  for(std::vector<RegularReplace>::const_iterator it = this->GraphNodeNameFilters.begin();
+      it != this->GraphNodeNameFilters.end();
+      ++it)
+    name = RegexReplace(name, it->first, it->second); 
 
   return name;
 }

--- a/Source/cmGraphVizWriter.h
+++ b/Source/cmGraphVizWriter.h
@@ -62,7 +62,7 @@ protected:
   void WriteFooter(cmGeneratedFileStream& str) const;
 
   bool IgnoreThisTarget(const std::string& name);
-  std::string MangleNodeName(std::string name);
+  std::string MangleNodeName(std::string name) const;
 
   bool GenerateForTargetType(cmTarget::TargetType targetType) const;
 
@@ -78,7 +78,6 @@ protected:
   bool GenerateForExternals;
   bool GeneratePerTarget;
   bool GenerateDependers;
-  bool GenerateGrouped;
 
   std::vector<cmsys::RegularExpression> TargetsToIgnoreRegex;
   typedef std::pair<std::regex, std::string> RegularReplace;

--- a/Source/cmGraphVizWriter.h
+++ b/Source/cmGraphVizWriter.h
@@ -16,7 +16,6 @@
 #include "cmGeneratedFileStream.h"
 #include "cmTarget.h"
 #include <cmsys/RegularExpression.hxx>
-#include <regex>
 
 
 /** This class implements writing files for graphviz (dot) for graphs
@@ -80,7 +79,7 @@ protected:
   bool GenerateDependers;
 
   std::vector<cmsys::RegularExpression> TargetsToIgnoreRegex;
-  typedef std::pair<std::regex, std::string> RegularReplace;
+  typedef std::pair<std::string, std::string> RegularReplace;
   std::vector<RegularReplace> GraphNodeNameFilters;
 
   const std::vector<cmLocalGenerator*>& LocalGenerators;

--- a/Source/cmGraphVizWriter.h
+++ b/Source/cmGraphVizWriter.h
@@ -16,6 +16,7 @@
 #include "cmGeneratedFileStream.h"
 #include "cmTarget.h"
 #include <cmsys/RegularExpression.hxx>
+#include <regex>
 
 
 /** This class implements writing files for graphviz (dot) for graphs
@@ -61,6 +62,7 @@ protected:
   void WriteFooter(cmGeneratedFileStream& str) const;
 
   bool IgnoreThisTarget(const std::string& name);
+  std::string MangleNodeName(std::string name);
 
   bool GenerateForTargetType(cmTarget::TargetType targetType) const;
 
@@ -76,8 +78,11 @@ protected:
   bool GenerateForExternals;
   bool GeneratePerTarget;
   bool GenerateDependers;
+  bool GenerateGrouped;
 
   std::vector<cmsys::RegularExpression> TargetsToIgnoreRegex;
+  typedef std::pair<std::regex, std::string> RegularReplace;
+  std::vector<RegularReplace> GraphNodeNameFilters;
 
   const std::vector<cmLocalGenerator*>& LocalGenerators;
 

--- a/Source/cmRegexTools.cxx
+++ b/Source/cmRegexTools.cxx
@@ -1,0 +1,155 @@
+/*============================================================================
+  CMake - Cross Platform Makefile Generator
+  Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
+
+  Distributed under the OSI-approved BSD License (the "License");
+  see accompanying file Copyright.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even the
+  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the License for more information.
+============================================================================*/
+#include "cmRegexTools.h"
+
+#include <cmsys/RegularExpression.hxx>
+
+#include <vector>
+
+//----------------------------------------------------------------------------
+namespace
+{
+  class RegexReplacement
+  {
+  public:
+    RegexReplacement(const char* s): number(-1), value(s) {}
+    RegexReplacement(const std::string& s): number(-1), value(s) {}
+    RegexReplacement(int n): number(n), value() {}
+    RegexReplacement() {}
+    int number;
+    std::string value;
+  };
+}
+//----------------------------------------------------------------------------
+std::string RegexReplace(std::string const& input, std::string const& regex, std::string const& replace)
+{
+  // Pull apart the replace expression to find the escaped [0-9] values.
+  std::vector<RegexReplacement> replacement;
+  std::string::size_type l = 0;
+  while(l < replace.length())
+    {
+    std::string::size_type r = replace.find("\\", l);
+    if(r == std::string::npos)
+      {
+      r = replace.length();
+      replacement.push_back(replace.substr(l, r-l));
+      }
+    else
+      {
+      if(r-l > 0)
+        {
+        replacement.push_back(replace.substr(l, r-l));
+        }
+      if(r == (replace.length()-1))
+        {
+//        this->SetError("sub-command REGEX, mode REPLACE: "
+//                       "replace-expression ends in a backslash.");
+        return input;
+        }
+      if((replace[r+1] >= '0') && (replace[r+1] <= '9'))
+        {
+        replacement.push_back(replace[r+1]-'0');
+        }
+      else if(replace[r+1] == 'n')
+        {
+        replacement.push_back("\n");
+        }
+      else if(replace[r+1] == '\\')
+        {
+        replacement.push_back("\\");
+        }
+      else
+        {
+        std::string e = "sub-command REGEX, mode REPLACE: Unknown escape \"";
+        e += replace.substr(r, 2);
+        e += "\" in replace-expression.";
+//        this->SetError(e);
+        return input;
+        }
+      r += 2;
+      }
+    l = r;
+    }
+
+  // Compile the regular expression.
+  cmsys::RegularExpression re;
+  if(!re.compile(regex.c_str()))
+    {
+    std::string e =
+      "sub-command REGEX, mode REPLACE failed to compile regex \""+
+      regex+"\".";
+//    this->SetError(e);
+    return input;
+    }
+
+  // Scan through the input for all matches.
+  std::string output;
+  std::string::size_type base = 0;
+  while(re.find(input.c_str()+base))
+    {
+//    this->Makefile->StoreMatches(re);
+    std::string::size_type l2 = re.start();
+    std::string::size_type r = re.end();
+
+    // Concatenate the part of the input that was not matched.
+    output += input.substr(base, l2);
+
+    // Make sure the match had some text.
+    if(r-l2 == 0)
+      {
+      std::string e = "sub-command REGEX, mode REPLACE regex \""+
+        regex+"\" matched an empty string.";
+//      this->SetError(e);
+      return input;
+      }
+
+    // Concatenate the replacement for the match.
+    for(unsigned int i=0; i < replacement.size(); ++i)
+      {
+      if(replacement[i].number < 0)
+        {
+        // This is just a plain-text part of the replacement.
+        output += replacement[i].value;
+        }
+      else
+        {
+        // Replace with part of the match.
+        int n = replacement[i].number;
+        std::string::size_type start = re.start(n);
+        std::string::size_type end = re.end(n);
+        std::string::size_type len = input.length()-base;
+        if((start != std::string::npos) && (end != std::string::npos) &&
+           (start <= len) && (end <= len))
+          {
+          output += input.substr(base+start, end-start);
+          }
+        else
+          {
+          std::string e =
+            "sub-command REGEX, mode REPLACE: replace expression \""+
+            replace+"\" contains an out-of-range escape for regex \""+
+            regex+"\".";
+//          this->SetError(e);
+          return input;
+          }
+        }
+      }
+
+    // Move past the match.
+    base += r;
+    }
+
+  // Concatenate the text after the last match.
+  output += input.substr(base, input.length()-base);
+
+  return output;
+}

--- a/Source/cmRegexTools.h
+++ b/Source/cmRegexTools.h
@@ -1,0 +1,20 @@
+/*============================================================================
+  CMake - Cross Platform Makefile Generator
+  Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
+
+  Distributed under the OSI-approved BSD License (the "License");
+  see accompanying file Copyright.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even the
+  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the License for more information.
+============================================================================*/
+#ifndef cmRegexTools_h
+#define cmRegexTools_h
+
+#include <string>
+
+std::string RegexReplace(std::string const& input, std::string const& regex, std::string const& replace);
+
+
+#endif

--- a/Source/cmStringCommand.h
+++ b/Source/cmStringCommand.h
@@ -76,16 +76,6 @@ protected:
   bool HandleGenexStripCommand(std::vector<std::string> const& args);
   bool HandleUuidCommand(std::vector<std::string> const& args);
 
-  class RegexReplacement
-  {
-  public:
-    RegexReplacement(const char* s): number(-1), value(s) {}
-    RegexReplacement(const std::string& s): number(-1), value(s) {}
-    RegexReplacement(int n): number(n), value() {}
-    RegexReplacement() {}
-    int number;
-    std::string value;
-  };
 };
 
 


### PR DESCRIPTION
Not ready to merge! But I think we can use this for discussion .

What this pull request is about:
When generating a dependency graph of a large project with many external libraries, there are so many external libs that one doesn't see the important dependencies any more. 
So with this patch, I can define regex replace rules to group the external libraries together. The replace rule I mentioned in the documentation gives me only one graph node for all boost libraries, only one graph node for the visualization library, and only one node for the numerics library.

My first implementation was using std::regex, but since cmake has to compile with older compilers, I extracted the RegexReplace functionality from the string processor, and put it in a new file. For the moment I commented out the error reporting. I'm not sure how that would be handled best. That's where I could use some input.