### PR TITLE
Make cmake-mode support prog-mode hooks.

### DIFF
--- a/Auxiliary/cmake-mode.el
+++ b/Auxiliary/cmake-mode.el
@@ -259,7 +259,9 @@ the indentation.  Otherwise it retains the same position on the line"
   (setq comment-start "#")
 
   ; Run user hooks.
-  (run-hooks 'cmake-mode-hook))
+  (if (boundp 'prog-mode-hook)
+      (run-hooks 'prog-mode-hook 'cmake-mode-hook)
+    (run-hooks 'cmake-mode-hook)))
 
 ; Help mode starts here
 


### PR DESCRIPTION
Since version24, Emacs supports a generic mode called `prog-mode`. Like all other modes it has its own mode-hook, `prog-mode-hook`. For emacs users it's common to provide all your generic programming-mode related customizations in this mode-hook.

`cmake-mode` is definitely a programming-mode and should support calling this hook. There are two ways to make that happen:

* Make your major-mode a derived-mode from `prog-mode`.
* Manually calling the hook upon mode-activation.

Implementing a derived mode may be the most proper thing to do (and was attempted in [this closed PR](https://github.com/Kitware/CMake/pull/146)), but as can be seen there it does cause quite a bit of structural changes.

However just calling the hook will cover the needs of 99% of the Emacs-users and requires almost no changes at all.

So that's what this patch does, but only after checking that the mode-hook exists to avoid compatibility issues with older versions of Emacs.