### PR TITLE
FindXercesC: Find versioned library on Windows

### DIFF
--- a/Modules/FindXercesC.cmake
+++ b/Modules/FindXercesC.cmake
@@ -62,7 +62,7 @@ find_path(XercesC_INCLUDE_DIR
 mark_as_advanced(XercesC_INCLUDE_DIR)
 
 # Find all XercesC libraries
-find_library(XercesC_LIBRARY "xerces-c"
+find_library(XercesC_LIBRARY NAMES "xerces-c" "xerces-c_3"
   DOC "Xerces-C++ libraries")
 mark_as_advanced(XercesC_LIBRARY)
 


### PR DESCRIPTION
The MSVC solution/project files provided by upstream add a `_3` suffix to the `.lib` files, and this is also present in the binary builds packaged for Windows.  Check for this in addition to the regular name.