### PR TITLE
FindXercesC: Also search for xerces-c_2 (#15648)

### DIFF
--- a/Modules/FindXercesC.cmake
+++ b/Modules/FindXercesC.cmake
@@ -62,7 +62,7 @@ find_path(XercesC_INCLUDE_DIR
 mark_as_advanced(XercesC_INCLUDE_DIR)
 
 # Find all XercesC libraries
-find_library(XercesC_LIBRARY NAMES "xerces-c" "xerces-c_3"
+find_library(XercesC_LIBRARY NAMES "xerces-c" "xerces-c_3" "xerces-c_2"
   DOC "Xerces-C++ libraries")
 mark_as_advanced(XercesC_LIBRARY)
 


### PR DESCRIPTION
This is the previous stable release name used on Windows.