### PR TITLE
Allow finding static libraries linking OpenSSL through Find package module [WINDOWS ONLY]

### DIFF
--- a/Modules/FindOpenSSL.cmake
+++ b/Modules/FindOpenSSL.cmake
@@ -116,13 +116,13 @@ if(WIN32 AND NOT CYGWIN)
     # enable OPENSSL_USE_STATIC to use the static libs located in lib/VC/static
 
     if(OPENSSL_USE_STATIC)
-      set(_OPENSLL_PATH_SUFFIXES
+      set(_OPENSSL_PATH_SUFFIXES
         "lib"
         "VC/static"
         "lib/VC/static"
         )
     else()
-      set(_OPENSLL_PATH_SUFFIXES
+      set(_OPENSSL_PATH_SUFFIXES
         "lib"
         "VC"
         "lib/VC"

--- a/Modules/FindOpenSSL.cmake
+++ b/Modules/FindOpenSSL.cmake
@@ -36,6 +36,7 @@
 # ^^^^^
 #
 # Set ``OPENSSL_ROOT_DIR`` to the root directory of an OpenSSL installation.
+# Set ``OPENSSL_USE_STATIC`` to use static libraries.
 
 #=============================================================================
 # Copyright 2006-2009 Kitware, Inc.
@@ -56,6 +57,16 @@ if (UNIX)
   find_package(PkgConfig QUIET)
   pkg_check_modules(_OPENSSL QUIET openssl)
 endif ()
+
+# Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
+if (OPENSSL_USE_STATIC)
+  set( _openssl_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  if(WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
+  endif()
+endif()
 
 if (WIN32)
   # http://www.slproweb.com/products/Win32OpenSSL.html
@@ -422,4 +433,9 @@ if(OPENSSL_FOUND)
         INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)
     endif()
   endif()
+endif()
+
+# Restore the original find library ordering
+if( OPENSSL_USE_STATIC )
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_openssl_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
 endif()

--- a/Modules/FindOpenSSL.cmake
+++ b/Modules/FindOpenSSL.cmake
@@ -113,12 +113,21 @@ if(WIN32 AND NOT CYGWIN)
     # We are using the libraries located in the VC subdir instead of the parent directory eventhough :
     # libeay32MD.lib is identical to ../libeay32.lib, and
     # ssleay32MD.lib is identical to ../ssleay32.lib
+    # enable OPENSSL_USE_STATIC to use the static libs located in lib/VC/static
 
-    set(_OPENSSL_PATH_SUFFIXES
-      "lib"
-      "VC"
-      "lib/VC"
-      )
+    if(OPENSSL_USE_STATIC)
+      set(_OPENSLL_PATH_SUFFIXES
+        "lib"
+        "VC/static"
+        "lib/VC/static"
+        )
+    else()
+      set(_OPENSLL_PATH_SUFFIXES
+        "lib"
+        "VC"
+        "lib/VC"
+        )
+    endif ()
 
     find_library(LIB_EAY_DEBUG
       NAMES


### PR DESCRIPTION
win-only:
set(OPENSSL_USE_STATIC 1) before the find_package(OpenSSL) command to get a static linking library rather then having to depend on a DLL