### PR TITLE
GenerateExportHeader: Add EXPORT_TEMPLATE macro

### DIFF
--- a/Modules/exportheader.cmake.in
+++ b/Modules/exportheader.cmake.in
@@ -4,15 +4,18 @@
 
 #ifdef @STATIC_DEFINE@
 #  define @EXPORT_MACRO_NAME@
+#  define @EXPORT_MACRO_NAME@_TEMPLATE
 #  define @NO_EXPORT_MACRO_NAME@
 #else
 #  ifndef @EXPORT_MACRO_NAME@
 #    ifdef @EXPORT_IMPORT_CONDITION@
         /* We are building this library */
 #      define @EXPORT_MACRO_NAME@ @DEFINE_EXPORT@
+#      define @EXPORT_MACRO_NAME@_TEMPLATE
 #    else
         /* We are using this library */
 #      define @EXPORT_MACRO_NAME@ @DEFINE_IMPORT@
+#      define @EXPORT_MACRO_NAME@_TEMPLATE extern
 #    endif
 #  endif
 


### PR DESCRIPTION
In addition to the foo_EXPORT macro, a foo_EXPORT_TEMPLATE macro is also generated.  This is to allow for explicit export of templates in Windows DLLs following Microsoft's guidance here: https://support.microsoft.com/en-us/kb/168958

I'm unaware if there were reasons for this not already being included in the export header, but it appears necessary to properly export templates, and without reinventing the logic in the header to define your own equivalents.  Should be pretty safe to add since it won't affect existing users of GenerateExportHeader.