### PR TITLE
Add VS_WINDOWS_TARGET_PLATFORM_VERSION

### DIFF
--- a/Help/manual/cmake-properties.7.rst
+++ b/Help/manual/cmake-properties.7.rst
@@ -265,6 +265,7 @@ Properties on Targets
    /prop_tgt/VS_SCC_LOCALPATH
    /prop_tgt/VS_SCC_PROJECTNAME
    /prop_tgt/VS_SCC_PROVIDER
+   /prop_tgt/VS_WINDOWS_TARGET_PLATFORM_VERSION
    /prop_tgt/VS_WINRT_COMPONENT
    /prop_tgt/VS_WINRT_EXTENSIONS
    /prop_tgt/VS_WINRT_REFERENCES

--- a/Help/prop_tgt/VS_WINDOWS_TARGET_PLATFORM_VERSION.rst
+++ b/Help/prop_tgt/VS_WINDOWS_TARGET_PLATFORM_VERSION.rst
@@ -1,0 +1,7 @@
+VS_WINDOWS_TARGET_PLATFORM_VERSION
+----------------------------------
+
+Specify the target Windows SDK version.
+
+Used to set the Windows SDK target version in Visual Studio 14 (2015) and
+newer.

--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -444,6 +444,13 @@ void cmVisualStudio10TargetGenerator::Generate()
     (*this->BuildFileStream) << cmVS10EscapeXML(targetFrameworkVersion)
                              << "</TargetFrameworkVersion>\n";
     }
+  if(const char* windowsTargetPlatformVersion = this->Target->GetProperty(
+       "VS_WINDOWS_TARGET_PLATFORM_VERSION"))
+    {
+    this->WriteString("<WindowsTargetPlatformVersion>", 2);
+    (*this->BuildFileStream) << cmVS10EscapeXML(windowsTargetPlatformVersion)
+                             << "</WindowsTargetPlatformVersion>\n";
+    }
   this->WriteString("</PropertyGroup>\n", 1);
   this->WriteString("<Import Project="
                     "\"$(VCTargetsPath)\\Microsoft.Cpp.Default.props\" />\n",


### PR DESCRIPTION
Sets the Windows SDK target for Visual Studio 2015 projects. Used
to build against the Windows 10 SDK. It's analogous to the existing
property for TargetFrameworkVersion in .NET.