### PR TITLE
Emacs mode: font-lock regexps

### DIFF
--- a/Auxiliary/cmake-mode.el
+++ b/Auxiliary/cmake-mode.el
@@ -200,7 +200,7 @@ the indentation.  Otherwise it retains the same position on the line"
      . font-lock-keyword-face)
     (,(rx symbol-start (group (+ (or word (syntax symbol)))) (* blank) ?\()
      1 font-lock-function-name-face)
-    ("\\${?\\([[:alpha:]_][[:alnum:]_]*\\|[0-9]+\\|[$*_]\\)"
+    (,(rx "${" (group (+(any alnum "-_+/."))) "}")
      1 font-lock-variable-name-face t)
     )
   "Highlighting expressions for CMake mode.")

--- a/Auxiliary/cmake-mode.el
+++ b/Auxiliary/cmake-mode.el
@@ -198,7 +198,7 @@ the indentation.  Otherwise it retains the same position on the line"
                               ,@(mapcar #'downcase cmake-keywords))
                           symbol-end))
      . font-lock-keyword-face)
-    (,(rx symbol-start (group (+ (or word (syntax symbol)))) ?\()
+    (,(rx symbol-start (group (+ (or word (syntax symbol)))) (* blank) ?\()
      1 font-lock-function-name-face)
     ("\\${?\\([[:alpha:]_][[:alnum:]_]*\\|[0-9]+\\|[$*_]\\)"
      1 font-lock-variable-name-face t)


### PR DESCRIPTION
Fixes regular expression for function names, to allow a space between the name and parenthesis.

Adds `- . + /` to variable name regexp, and removes `$ *`.
Removing `$` fixes font-lock in nested substitutions: e.g. in `${${FOO}}` only the second `$` was highlighted; now `FOO` is. Otherwise behavior is the same.