### PR TITLE
Add support for HiDPI (Retina) screens in Qt GUI.

### DIFF
--- a/Source/QtDialog/Info.plist.in
+++ b/Source/QtDialog/Info.plist.in
@@ -28,5 +28,7 @@
 	<string>public.app-category.developer-tools</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Proposing minor change to add HiDPI (Retina) support to the Qt GUI.

It is activated by setting `NSHighResolutionCapable` to `true` in the Info.plist of the application.

Here are two screenshots showing the Qt GUI before and after the change:
![before](https://cloud.githubusercontent.com/assets/1174092/9302187/edb48262-44d4-11e5-8738-2d5825832437.png)
<img width="834" alt="after" src="https://cloud.githubusercontent.com/assets/1174092/9302194/f96ded46-44d4-11e5-8e28-583a1f9291d0.png">

