### PR TITLE
Add support for RESW files to VS generator.

### DIFF
--- a/Source/cmGeneratorTarget.cxx
+++ b/Source/cmGeneratorTarget.cxx
@@ -61,6 +61,7 @@ struct HeaderSourcesTag {};
 struct ExternalObjectsTag {};
 struct IDLSourcesTag {};
 struct ResxTag {};
+struct ReswTag {};
 struct ModuleDefinitionFileTag {};
 struct AppManifestTag{};
 struct CertificatesTag{};
@@ -120,6 +121,10 @@ struct DoAccept<true>
     data.ExpectedXamlHeaders.insert(hFileName);
     data.ExpectedXamlSources.insert(cppFileName);
     data.XamlSources.push_back(f);
+    }
+  static void Do(cmGeneratorTarget::ReswData& data, cmSourceFile* f)
+    {
+    data.ReswSources.push_back(f);
     }
   static void Do(std::string& data, cmSourceFile* f)
     {
@@ -199,6 +204,10 @@ struct TagVisitor
     else if(ext == "resx")
       {
       DoAccept<IsSameTag<Tag, ResxTag>::Result>::Do(this->Data, sf);
+      }
+    else if(ext == "resw")
+      {
+      DoAccept<IsSameTag<Tag, ReswTag>::Result>::Do(this->Data, sf);
       }
     else if (ext == "appxmanifest")
       {
@@ -554,6 +563,16 @@ void cmGeneratorTarget
   ResxData data;
   IMPLEMENT_VISIT_IMPL(Resx, COMMA cmGeneratorTarget::ResxData)
   srcs = data.ResxSources;
+}
+
+//----------------------------------------------------------------------------
+void cmGeneratorTarget
+::GetReswSources(std::vector<cmSourceFile const*>& srcs,
+                 const std::string& config) const
+{
+  ReswData data;
+  IMPLEMENT_VISIT_IMPL(Resw, COMMA cmGeneratorTarget::ReswData)
+  srcs = data.ReswSources;
 }
 
 //----------------------------------------------------------------------------

--- a/Source/cmGeneratorTarget.h
+++ b/Source/cmGeneratorTarget.h
@@ -57,6 +57,8 @@ public:
 
   void GetResxSources(std::vector<cmSourceFile const*>&,
                       const std::string& config) const;
+  void GetReswSources(std::vector<cmSourceFile const*>&,
+                      const std::string& config) const;
   void GetIDLSources(std::vector<cmSourceFile const*>&,
                      const std::string& config) const;
   void GetExternalObjects(std::vector<cmSourceFile const*>&,
@@ -304,6 +306,10 @@ public:
   struct ResxData {
     mutable std::set<std::string> ExpectedResxHeaders;
     mutable std::vector<cmSourceFile const*> ResxSources;
+  };
+
+  struct ReswData {
+    mutable std::vector<cmSourceFile const*> ReswSources;
   };
 
   struct XamlData {

--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -472,6 +472,7 @@ void cmVisualStudio10TargetGenerator::Generate()
   this->WriteDotNetReferences();
   this->WriteEmbeddedResourceGroup();
   this->WriteXamlFilesGroup();
+  this->WriteReswGroup();
   this->WriteWinRTReferences();
   this->WriteProjectReferences();
   this->WriteString(
@@ -582,6 +583,23 @@ void cmVisualStudio10TargetGenerator::WriteXamlFilesGroup()
       this->WriteString("</", 2);
       (*this->BuildFileStream) << xamlType << ">\n";
 
+      }
+    this->WriteString("</ItemGroup>\n", 1);
+    }
+}
+
+void cmVisualStudio10TargetGenerator::WriteReswGroup()
+{
+  std::vector<cmSourceFile const*> reswObjs;
+    this->GeneratorTarget->GetReswSources(reswObjs, "");
+  if(!reswObjs.empty())
+    {
+    this->WriteString("<ItemGroup>\n", 1);
+    for(std::vector<cmSourceFile const*>::const_iterator oi = reswObjs.begin();
+        oi != reswObjs.end(); ++oi)
+      {
+      std::string obj = (*oi)->GetFullPath();
+      this->WriteSource("PRIResource", *oi);
       }
     this->WriteString("</ItemGroup>\n", 1);
     }

--- a/Source/cmVisualStudio10TargetGenerator.h
+++ b/Source/cmVisualStudio10TargetGenerator.h
@@ -67,6 +67,7 @@ private:
   void WriteAllSources();
   void WriteDotNetReferences();
   void WriteEmbeddedResourceGroup();
+  void WriteReswGroup();
   void WriteWinRTReferences();
   void WriteWinRTPackageCertificateKeyFile();
   void WriteXamlFilesGroup();


### PR DESCRIPTION
Add support for RESW files to Visual Studio 2010+ generatos. Resw files
are added as PRIResource element.

Conflicts:
	Source/cmGeneratorTarget.cxx
	Source/cmGeneratorTarget.h
	Source/cmVisualStudio10TargetGenerator.cxx
	Source/cmVisualStudio10TargetGenerator.h