### PR TITLE
FindGit: add support for SourceTree on Windows

### DIFF
--- a/Modules/FindGit.cmake
+++ b/Modules/FindGit.cmake
@@ -48,12 +48,14 @@ if(WIN32)
     # GitHub search path for Windows
     set(github_path "$ENV{LOCALAPPDATA}/Github/PortableGit*/bin")
     file(GLOB github_path "${github_path}")
+    # SourceTree search path for Windows
+    set(sourcetree_path "$ENV{LOCALAPPDATA}/Atlassian/SourceTree/git_local/bin")
   endif()
 endif()
 
 find_program(GIT_EXECUTABLE
   NAMES ${git_names}
-  PATHS ${github_path}
+  PATHS ${github_path} ${sourcetree_path}
   PATH_SUFFIXES Git/cmd Git/bin
   DOC "git command line client"
   )


### PR DESCRIPTION
Fixes Mantis bug [#15758](https://public.kitware.com/Bug/view.php?id=15758)