### PR TITLE
Fix off-by-one when adding two times

### DIFF
--- a/Source/kwsys/ProcessUNIX.c
+++ b/Source/kwsys/ProcessUNIX.c
@@ -2241,7 +2241,7 @@ static kwsysProcessTime kwsysProcessTimeAdd(kwsysProcessTime in1, kwsysProcessTi
   kwsysProcessTime out;
   out.tv_sec = in1.tv_sec + in2.tv_sec;
   out.tv_usec = in1.tv_usec + in2.tv_usec;
-  if(out.tv_usec > 1000000)
+  if(out.tv_usec >= 1000000)
     {
     out.tv_usec -= 1000000;
     out.tv_sec += 1;


### PR DESCRIPTION
Microseconds range from 0 to 999999, so 1000000 is an overflow which should be processed as well.