### PR TITLE
Allow GRAPHVIZ_GRAPH_NAME to contain spaces without requiring escaped quotes.

### DIFF
--- a/Source/cmGraphVizWriter.cxx
+++ b/Source/cmGraphVizWriter.cxx
@@ -292,7 +292,7 @@ void cmGraphVizWriter::WriteGlobalFile(const char* fileName)
 
 void cmGraphVizWriter::WriteHeader(cmGeneratedFileStream& str) const
 {
-  str << this->GraphType << " " << this->GraphName << " {" << std::endl;
+  str << this->GraphType << " \"" << this->GraphName << "\" {" << std::endl;
   str << this->GraphHeader << std::endl;
 }
 


### PR DESCRIPTION
Without this patch, `SET (GRAPHVIZ_GRAPH_NAME "hello world")` does not work (it results in a parsing error in GraphViz when the generated output is processed), but `SET (GRAPHVIZ_GRAPH_NAME "\"hello world\"")` does.