### PR TITLE
Put ${_pkgconfig_path} in quotes to protect semicolons on Windows.

### DIFF
--- a/Modules/FindPkgConfig.cmake
+++ b/Modules/FindPkgConfig.cmake
@@ -285,7 +285,7 @@ macro(_pkg_check_modules_internal _is_required _is_silent _no_cmake_path _no_cma
           string(REPLACE ";" ":" _pkgconfig_path "${_pkgconfig_path}")
           string(REPLACE "\\ " " " _pkgconfig_path "${_pkgconfig_path}")
         endif()
-        set(ENV{PKG_CONFIG_PATH} ${_pkgconfig_path})
+        set(ENV{PKG_CONFIG_PATH} "${_pkgconfig_path}")
       endif()
 
       # Unset variables


### PR DESCRIPTION
Consider the case on Windows where the pkgconfig_path is multiple directories separated by semicolons (.e.g, "c:\foo;c:\bar;c:\baz"). In the existing code, this path would be interpreted as list and ENV{PKG_CONFIG_PATH} would only get the first item in the path. 