### PR TITLE
Allow users of CheckCXXSourceRuns and CheckCSourceRuns to access the …

### DIFF
--- a/Modules/CheckCSourceRuns.cmake
+++ b/Modules/CheckCSourceRuns.cmake
@@ -69,7 +69,8 @@ macro(CHECK_C_SOURCE_RUNS SOURCE VAR)
       CMAKE_FLAGS -DCOMPILE_DEFINITIONS:STRING=${MACRO_CHECK_FUNCTION_DEFINITIONS}
       -DCMAKE_SKIP_RPATH:BOOL=${CMAKE_SKIP_RPATH}
       "${CHECK_C_SOURCE_COMPILES_ADD_INCLUDES}"
-      COMPILE_OUTPUT_VARIABLE OUTPUT)
+      COMPILE_OUTPUT_VARIABLE OUTPUT
+      RUN_OUTPUT_VARIABLE RUN_OUTPUT)
     # if it did not compile make the return value fail code of 1
     if(NOT ${VAR}_COMPILED)
       set(${VAR}_EXITCODE 1)
@@ -84,6 +85,7 @@ macro(CHECK_C_SOURCE_RUNS SOURCE VAR)
         "Performing C SOURCE FILE Test ${VAR} succeeded with the following output:\n"
         "${OUTPUT}\n"
         "Return value: ${${VAR}}\n"
+        "Run output: ${RUN_OUTPUT}\n"
         "Source file was:\n${SOURCE}\n")
     else()
       if(CMAKE_CROSSCOMPILING AND "${${VAR}_EXITCODE}" MATCHES  "FAILED_TO_RUN")

--- a/Modules/CheckCXXSourceRuns.cmake
+++ b/Modules/CheckCXXSourceRuns.cmake
@@ -69,7 +69,8 @@ macro(CHECK_CXX_SOURCE_RUNS SOURCE VAR)
       CMAKE_FLAGS -DCOMPILE_DEFINITIONS:STRING=${MACRO_CHECK_FUNCTION_DEFINITIONS}
       -DCMAKE_SKIP_RPATH:BOOL=${CMAKE_SKIP_RPATH}
       "${CHECK_CXX_SOURCE_COMPILES_ADD_INCLUDES}"
-      COMPILE_OUTPUT_VARIABLE OUTPUT)
+      COMPILE_OUTPUT_VARIABLE OUTPUT
+      RUN_OUTPUT_VARIABLE RUN_OUTPUT)
 
     # if it did not compile make the return value fail code of 1
     if(NOT ${VAR}_COMPILED)
@@ -85,6 +86,7 @@ macro(CHECK_CXX_SOURCE_RUNS SOURCE VAR)
         "Performing C++ SOURCE FILE Test ${VAR} succeeded with the following output:\n"
         "${OUTPUT}\n"
         "Return value: ${${VAR}}\n"
+        "Run output: ${RUN_OUTPUT}\n"
         "Source file was:\n${SOURCE}\n")
     else()
       if(CMAKE_CROSSCOMPILING AND "${${VAR}_EXITCODE}" MATCHES  "FAILED_TO_RUN")


### PR DESCRIPTION
…output from the run

While making custom finders for 3rd party libraries I was faced with some that didn't allow the version to be stripped from the header. To get around that I can use CheckCXXSourceRuns to make and run a small .cpp file which prints the version to stdout. This allows me to grab that using CheckCXXSourceRuns rather than try_run which is more difficult to use.