### PR TITLE
Added functionality to set RemoteDirectory in DeploymentTool and Debu…

### DIFF
--- a/Help/manual/cmake-properties.7.rst
+++ b/Help/manual/cmake-properties.7.rst
@@ -141,6 +141,7 @@ Properties on Targets
    /prop_tgt/CXX_STANDARD_REQUIRED
    /prop_tgt/DEBUG_POSTFIX
    /prop_tgt/DEFINE_SYMBOL
+   /prop_tgt/DEPLOYMENT_REMOTE_DIRECTORY
    /prop_tgt/EchoString
    /prop_tgt/ENABLE_EXPORTS
    /prop_tgt/EXCLUDE_FROM_ALL

--- a/Help/prop_tgt/DEPLOYMENT_REMOTE_DIRECTORY.rst
+++ b/Help/prop_tgt/DEPLOYMENT_REMOTE_DIRECTORY.rst
@@ -1,0 +1,24 @@
+DEPLOYMENT_REMOTE_DIRECTORY 
+------
+
+Set RemoteDirectory in DeploymentTool and RemoteExecutable in DebuggerTool section in vcproj configuration for VisualStudio 2005 and 2008. 
+
+This functionality is only for WinCE project.
+
+This is useful when you want to debug on remote WinCE device.
+
+E.g.
+set_target_properties(${TARGET} PROPERTIES
+			DEPLOYMENT_REMOTE_DIRECTORY  "\\FlashStorage"
+)
+
+creates section in vcproj->VisualStudioProject->Configurations->Configuration:
+<DeploymentTool
+	ForceDirty="-1"
+	RemoteDirectory="\FlashStorage"
+	RegisterOutput="0"
+	AdditionalFiles=""/>
+<DebuggerTool
+	RemoteExecutable="\FlashStorage\target_full_name"
+	Arguments=""
+/>

--- a/Source/cmLocalVisualStudio7Generator.cxx
+++ b/Source/cmLocalVisualStudio7Generator.cxx
@@ -1012,6 +1012,7 @@ void cmLocalVisualStudio7Generator::WriteConfiguration(std::ostream& fout,
 
   this->OutputTargetRules(fout, configName, target, libName);
   this->OutputBuildTool(fout, configName, target, targetOptions);
+  this->OutputDeploymentDebuggerTool(fout, target);
   fout << "\t\t</Configuration>\n";
 }
 
@@ -1372,6 +1373,26 @@ void cmLocalVisualStudio7Generator::OutputBuildTool(std::ostream& fout,
     case cmState::INTERFACE_LIBRARY:
       break;
     }
+}
+
+void cmLocalVisualStudio7Generator::OutputDeploymentDebuggerTool(std::ostream& fout, cmGeneratorTarget* target)
+{
+	if (this->WindowsCEProject)
+	{
+		const char* targetRemoteDirectoryProperty = target->GetProperty("DEPLOYMENT_REMOTE_DIRECTORY");
+		if(targetRemoteDirectoryProperty)
+		{
+			fout << "\t\t\t<DeploymentTool\n"
+				<< "\t\t\t\tForceDirty=\"-1\"\n"
+				<< "\t\t\t\tRemoteDirectory=\"" << targetRemoteDirectoryProperty << "\"\n"
+				<< "\t\t\t\tRegisterOutput=\"0\"\n"
+				<< "\t\t\t\tAdditionalFiles=\"\"/>\n";
+			fout << "\t\t\t<DebuggerTool\n"
+				<< "\t\t\t\tRemoteExecutable=\"" << targetRemoteDirectoryProperty << "\\" << target->GetFullName() << "\"\n"
+				<< "\t\t\t\tArguments=\"\"\n"
+				<< "\t\t\t/>\n";
+		}
+	}
 }
 
 //----------------------------------------------------------------------------

--- a/Source/cmLocalVisualStudio7Generator.h
+++ b/Source/cmLocalVisualStudio7Generator.h
@@ -92,6 +92,12 @@ private:
                          const std::string& libName);
   void OutputBuildTool(std::ostream& fout, const std::string& configName,
                        cmGeneratorTarget* t, const Options& targetOptions);
+  /**
+   * functionality to set RemoteDirectory in DeploymentTool and DebuggerTool section in vcproj configuration for VisualStudio
+   * You can set path_to_remote_dir to target property DEPLOYMENT_REMOTE_DIRECTORY in your CMakeList.txt
+   * This functionality is only for WinCE project
+   */  
+  void OutputDeploymentDebuggerTool(std::ostream& fout, cmGeneratorTarget* target);
   void OutputLibraryDirectories(std::ostream& fout,
                                 std::vector<std::string> const& dirs);
   void WriteProjectSCC(std::ostream& fout, cmGeneratorTarget *target);


### PR DESCRIPTION
…ggerTool section in vcproj configuration for VisualStudio7Generator. You can set path_to_remote_dir to target property REMOTE_DIRECTORY in your CMakeList.txt.

This functionality is only for WinCE project.

E.g.
set_target_properties(${TARGET} PROPERTIES
			REMOTE_DIRECTORY "\\FlashStorage"
)
creates section in vcproj->VisualStudioProject->Configurations->Configuration:
<DeploymentTool
	ForceDirty="-1"
	RemoteDirectory="\FlashStorage"
	RegisterOutput="0"
	AdditionalFiles=""/>
<DebuggerTool
	RemoteExecutable="\FlashStorage\target_full_name"
	Arguments=""
/>