### PR TITLE
Created modules for Cygwin-Clang

### DIFF
--- a/Modules/Platform/CYGWIN-Clang-C.cmake
+++ b/Modules/Platform/CYGWIN-Clang-C.cmake
@@ -1,0 +1,2 @@
+include(Platform/CYGWIN-GNU)
+__cygwin_compiler_gnu(C)

--- a/Modules/Platform/CYGWIN-Clang-CXX.cmake
+++ b/Modules/Platform/CYGWIN-Clang-CXX.cmake
@@ -1,0 +1,2 @@
+include(Platform/CYGWIN-GNU)
+__cygwin_compiler_gnu(CXX)


### PR DESCRIPTION
When building a shared library with clang, the import library was not generated in Cygwin.
The cmake module for GNU can be reused for Clang, because clang accepts almost all of the options for gcc.