### PR TITLE
Better detection of K&R compilers.

### DIFF
--- a/Modules/CMakeCCompilerABI.c
+++ b/Modules/CMakeCCompilerABI.c
@@ -2,7 +2,7 @@
 # error "A C++ compiler has been selected for C."
 #endif
 
-#ifdef __CLASSIC_C__
+#if !defined(__STDC__) || __STDC__ == 0
 # define const
 #endif
 
@@ -12,7 +12,7 @@
 
 /*--------------------------------------------------------------------------*/
 
-#ifdef __CLASSIC_C__
+#if !defined(__STDC__) || __STDC__ == 0
 int main(argc, argv) int argc; char *argv[];
 #else
 int main(int argc, char *argv[])

--- a/Modules/CMakeCCompilerId.c.in
+++ b/Modules/CMakeCCompilerId.c.in
@@ -5,7 +5,7 @@
 #if defined(__18CXX)
 # define ID_VOID_MAIN
 #endif
-#if defined(__CLASSIC_C__)
+#if !defined(__STDC__) || __STDC__ == 0
 /* cv-qualifiers did not exist in K&R C */
 # define const
 # define volatile
@@ -33,7 +33,7 @@ char const *info_cray = "INFO" ":" "compiler_wrapper[CrayPrgEnv]";
 @CMAKE_C_COMPILER_ID_PLATFORM_CONTENT@
 @CMAKE_C_COMPILER_ID_ERROR_FOR_TEST@
 
-#if !defined(__STDC__)
+#if !defined(__STDC__) || __STDC__ == 0
 # define C_DIALECT
 #elif __STDC_VERSION__ >= 201000L
 # define C_DIALECT "11"
@@ -50,7 +50,7 @@ const char* info_language_dialect_default =
 #ifdef ID_VOID_MAIN
 void main() {}
 #else
-# if defined(__CLASSIC_C__)
+# if !defined(__STDC__) || __STDC__ == 0
 int main(argc, argv) int argc; char *argv[];
 # else
 int main(int argc, char* argv[])

--- a/Modules/CMakeDetermineCCompiler.cmake
+++ b/Modules/CMakeDetermineCCompiler.cmake
@@ -87,9 +87,6 @@ else()
 
     # Try enabling ANSI mode on HP.
     "-Aa"
-
-    # Try compiling K&R-compatible code (needed by Bruce C Compiler).
-    "-D__CLASSIC_C__"
     )
 endif()
 

--- a/Modules/CMakeTestCCompiler.cmake
+++ b/Modules/CMakeTestCCompiler.cmake
@@ -36,7 +36,7 @@ if(NOT CMAKE_C_COMPILER_WORKS)
     "#ifdef __cplusplus\n"
     "# error \"The CMAKE_C_COMPILER is set to a C++ compiler\"\n"
     "#endif\n"
-    "#if defined(__CLASSIC_C__)\n"
+    "#if !defined(__STDC__) || __STDC__ == 0\n"
     "int main(argc, argv)\n"
     "  int argc;\n"
     "  char* argv[];\n"

--- a/Modules/CheckForPthreads.c
+++ b/Modules/CheckForPthreads.c
@@ -5,13 +5,14 @@
 void* runner(void*);
 
 int res = 0;
-#ifdef __CLASSIC_C__
-int main(){
+#if !defined(__STDC__) || __STDC__ == 0
+int main(ac, av)
   int ac;
   char*av[];
 #else
-int main(int ac, char*av[]){
+int main(int ac, char*av[])
 #endif
+{
   pthread_t tid[2];
   pthread_create(&tid[0], 0, runner, (void*)1);
   pthread_create(&tid[1], 0, runner, (void*)2);

--- a/Modules/CheckFunctionExists.c
+++ b/Modules/CheckFunctionExists.c
@@ -4,13 +4,14 @@
 extern "C"
 #endif
 char CHECK_FUNCTION_EXISTS();
-#ifdef __CLASSIC_C__
-int main(){
+#if !defined(__STDC__) || __STDC__ == 0
+int main(ac, av)
   int ac;
   char*av[];
 #else
-int main(int ac, char*av[]){
+int main(int ac, char*av[])
 #endif
+{
   CHECK_FUNCTION_EXISTS();
   if(ac > 1000)
     {

--- a/Modules/CheckIncludeFile.c.in
+++ b/Modules/CheckIncludeFile.c.in
@@ -1,13 +1,10 @@
 #include <${CHECK_INCLUDE_FILE_VAR}>
 
-#ifdef __CLASSIC_C__
+#if !defined(__STDC__) || __STDC__ == 0
 int main()
-{
-  return 0;
-}
 #else
 int main(void)
+#endif
 {
   return 0;
 }
-#endif

--- a/Modules/CheckIncludeFiles.cmake
+++ b/Modules/CheckIncludeFiles.cmake
@@ -59,7 +59,7 @@ macro(CHECK_INCLUDE_FILES INCLUDE VARIABLE)
         "${CMAKE_CONFIGURABLE_FILE_CONTENT}#include <${FILE}>\n")
     endforeach()
     set(CMAKE_CONFIGURABLE_FILE_CONTENT
-      "${CMAKE_CONFIGURABLE_FILE_CONTENT}\n\nint main(void){return 0;}\n")
+      "${CMAKE_CONFIGURABLE_FILE_CONTENT}\n\n#if !defined(__STDC__) || __STDC == 0\nint main()\n#else\n  int main(void)\n#endif\n  {return 0;}\n")
     configure_file("${CMAKE_ROOT}/Modules/CMakeConfigurableFile.in"
       "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/CheckIncludeFiles.c" @ONLY)
 

--- a/Modules/CheckPrototypeDefinition.c.in
+++ b/Modules/CheckPrototypeDefinition.c.in
@@ -14,13 +14,14 @@ static void checkSymbol(void) {
   return @CHECK_PROTOTYPE_DEFINITION_RETURN@;
 }
 
-#ifdef __CLASSIC_C__
-int main() {
+#if !defined(__STDC__) || __STDC__ == 0
+int main(ac , av)
   int ac;
   char*av[];
 #else
-int main(int ac, char *av[]) {
+int main(int ac, char *av[])
 #endif
+{
   checkSymbol();
   if (ac > 1000) {
     return *av[0];

--- a/Modules/CheckSymbolExists.cmake
+++ b/Modules/CheckSymbolExists.cmake
@@ -75,7 +75,7 @@ macro(_CHECK_SYMBOL_EXISTS SOURCEFILE SYMBOL FILES VARIABLE)
         "${CMAKE_CONFIGURABLE_FILE_CONTENT}#include <${FILE}>\n")
     endforeach()
     set(CMAKE_CONFIGURABLE_FILE_CONTENT
-      "${CMAKE_CONFIGURABLE_FILE_CONTENT}\nint main(int argc, char** argv)\n{\n  (void)argv;\n#ifndef ${SYMBOL}\n  return ((int*)(&${SYMBOL}))[argc];\n#else\n  (void)argc;\n  return 0;\n#endif\n}\n")
+      "${CMAKE_CONFIGURABLE_FILE_CONTENT}\n#if !defined(__STDC__) || __STDC__ == 0\n  int main(argc, argv) int argc; char **argv;\n#else\n  int main(int argc, char** argv)\n#endif\n{\n  (void)argv;\n#ifndef ${SYMBOL}\n  return ((int*)(&${SYMBOL}))[argc];\n#else\n  (void)argc;\n  return 0;\n#endif\n}\n")
 
     configure_file("${CMAKE_ROOT}/Modules/CMakeConfigurableFile.in"
       "${SOURCEFILE}" @ONLY)

--- a/Modules/CheckTypeSize.c.in
+++ b/Modules/CheckTypeSize.c.in
@@ -24,7 +24,7 @@ char info_size[] =  {'I', 'N', 'F', 'O', ':', 's','i','z','e','[',
 #endif
   '\0'};
 
-#ifdef __CLASSIC_C__
+#if !defined(__STDC__) || __STDC__ == 0
 int main(argc, argv) int argc; char *argv[];
 #else
 int main(int argc, char *argv[])

--- a/Modules/CheckVariableExists.c
+++ b/Modules/CheckVariableExists.c
@@ -2,13 +2,14 @@
 
 extern int CHECK_VARIABLE_EXISTS;
 
-#ifdef __CLASSIC_C__
-int main(){
+#if !defined(__STDC__) || __STDC__ == 0
+int main(ac, av)
   int ac;
   char*av[];
 #else
-int main(int ac, char*av[]){
+int main(int ac, char*av[])
 #endif
+{
   if(ac > 1000){return *av[0];}
   return CHECK_VARIABLE_EXISTS;
 }

--- a/Modules/Compiler/Bruce-C.cmake
+++ b/Modules/Compiler/Bruce-C.cmake
@@ -1,7 +1,8 @@
 # Bruce C Compiler ignores "-g" flag and optimization cannot be
 # enabled here (it is implemented only for 8086 target).
-set (CMAKE_C_FLAGS_INIT "-D__CLASSIC_C__")
+set (CMAKE_C_FLAGS_INIT "")
 set (CMAKE_C_FLAGS_DEBUG_INIT "-g")
 set (CMAKE_C_FLAGS_MINSIZEREL_INIT "-DNDEBUG")
 set (CMAKE_C_FLAGS_RELEASE_INIT "-DNDEBUG")
 set (CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-g -DNDEBUG")
+

--- a/Modules/TestEndianess.c.in
+++ b/Modules/TestEndianess.c.in
@@ -1,6 +1,10 @@
 /* A 16 bit integer is required. */
 typedef @CMAKE_16BIT_TYPE@ cmakeint16;
 
+#if !defined(__STDC__) || __STDC__ == 0
+  #define const
+#endif
+
 /* On a little endian machine, these 16bit ints will give "THIS IS LITTLE ENDIAN."
    On a big endian machine the characters will be exchanged pairwise. */
 const cmakeint16 info_little[] =  {0x4854, 0x5349, 0x4920, 0x2053, 0x494c, 0x5454, 0x454c, 0x4520, 0x444e, 0x4149, 0x2e4e, 0x0000};
@@ -9,7 +13,7 @@ const cmakeint16 info_little[] =  {0x4854, 0x5349, 0x4920, 0x2053, 0x494c, 0x545
    On a little endian machine the characters will be exchanged pairwise. */
 const cmakeint16 info_big[] =     {0x5448, 0x4953, 0x2049, 0x5320, 0x4249, 0x4720, 0x454e, 0x4449, 0x414e, 0x2e2e, 0x0000};
 
-#ifdef __CLASSIC_C__
+#if !defined(__STDC__) || __STDC__ == 0
 int main(argc, argv) int argc; char *argv[];
 #else
 int main(int argc, char *argv[])

--- a/Source/kwsys/kwsysPlatformTestsC.c
+++ b/Source/kwsys/kwsysPlatformTestsC.c
@@ -25,11 +25,11 @@
       return 0;
     }
 */
-#if defined(__CLASSIC_C__)
+#if !defined(__STDC__) || __STDC__ == 0
 # define KWSYS_PLATFORM_TEST_C_MAIN() \
   main()
 # define KWSYS_PLATFORM_TEST_C_MAIN_ARGS(argc, argv) \
-  main(argc,argv) int argc; char* argv[];
+  main(argc, argv) int argc; char* argv[];
 #else
 # define KWSYS_PLATFORM_TEST_C_MAIN() \
   main(void)
@@ -40,20 +40,29 @@
 /*--------------------------------------------------------------------------*/
 #ifdef TEST_KWSYS_C_HAS_PTRDIFF_T
 #include <stddef.h>
-int f(ptrdiff_t n) { return n > 0; }
+#if !defined(__STDC__) || __STDC__ == 0
+int f(n) ptrdiff_t n;
+#else
+int f(ptrdiff_t n)
+#endif
+{ return n > 0; }
 int KWSYS_PLATFORM_TEST_C_MAIN()
 {
   char* p = 0;
   ptrdiff_t d = p - p;
-  (void)d;
-  return f(p - p);
+  return f(d);
 }
 #endif
 
 /*--------------------------------------------------------------------------*/
 #ifdef TEST_KWSYS_C_HAS_SSIZE_T
 #include <unistd.h>
-int f(ssize_t n) { return (int)n; }
+#if !defined(__STDC__) || __STDC__ == 0
+int f(n) ssize_t n;
+#else
+int f(ssize_t n)
+#endif
+{ return (int)n; }
 int KWSYS_PLATFORM_TEST_C_MAIN()
 {
   ssize_t n = 0;

--- a/Tests/Assembler/main.c
+++ b/Tests/Assembler/main.c
@@ -1,12 +1,13 @@
 #include <stdio.h>
 
-#ifdef __CLASSIC_C__
-int main(){
+#if !defined(__STDC__) || __STDC__ == 0
+int main(argc, argv)
   int argc;
   char*argv[];
 #else
-int main(int argc, char*argv[]){
+int main(int argc, char*argv[])
 #endif
+{
   printf("hello assembler world, %d arguments  given\n", argc);
   return 0;
 }

--- a/Tests/MacroTest/CMakeLists.txt
+++ b/Tests/MacroTest/CMakeLists.txt
@@ -51,13 +51,14 @@ include(CheckCSourceCompiles)
 Check_C_Source_Compiles(
 "
 #include <stdio.h>
-#ifdef __CLASSIC_C__
-int main(){
+#if !defined(__STDC__) || __STDC__ == 0
+int main(ac, av)
   int ac;
   char*av[];
 #else
-int main(int ac, char*av[]){
+int main(int ac, char*av[])
 #endif
+{
   if(ac > 1000){return *av[0];}
   return 0;
 }"

--- a/Tests/SimpleExclude/dirC/dirA/t4.c
+++ b/Tests/SimpleExclude/dirC/dirA/t4.c
@@ -1,14 +1,13 @@
 #include <stdio.h>
 
-#ifdef __CLASSIC_C__
-int main()
-{
+#if !defined(__STDC__) || __STDC__ == 0
+int main(ac, av)
   int ac;
   char*av[];
 #else
   int main(int ac, char*av[])
-    {
 #endif
+    {
     if(ac > 1000){return *av[0];}
     printf("This is T4. This one should work.\n");
     return 0;

--- a/Tests/SimpleExclude/dirD/t9.c
+++ b/Tests/SimpleExclude/dirD/t9.c
@@ -2,15 +2,14 @@
 
 extern int tlib7func();
 
-#ifdef __CLASSIC_C__
-int main()
-{
+#if !defined(__STDC__) || __STDC__ == 0
+int main(ac, av)
   int ac;
   char*av[];
 #else
   int main(int ac, char*av[])
-    {
 #endif
+    {
     if(ac > 1000){return *av[0];}
     printf("This is T9. This one should work.\n");
 

--- a/Tests/Wrapping/Wrap.c
+++ b/Tests/Wrapping/Wrap.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-#ifdef __CLASSIC_C__
+#if !defined(__STDC__) || __STDC__ == 0
 int main(argc, argv)
   int argc;
   char ** argv;

--- a/bootstrap
+++ b/bootstrap
@@ -839,7 +839,7 @@ echo '
 
 #include<stdio.h>
 
-#if defined(__CLASSIC_C__)
+#if !defined(__STDC__) || __STDC__ == 0
 int main(argc, argv)
   int argc;
   char* argv[];


### PR DESCRIPTION
__CLASSIC_C__ was HP-specific definition. __STDC__ should be more portable.
It should be defined to 1 for compilers conforming to ANSI C and newer standards.

Note: Some old compilers has __STDC__ defined to 0 to inform that they do not support function prototypes.