### PR TITLE
Use response files to compile obj files with Ninja

### DIFF
--- a/Source/cmGlobalNinjaGenerator.cxx
+++ b/Source/cmGlobalNinjaGenerator.cxx
@@ -230,7 +230,7 @@ void cmGlobalNinjaGenerator::WriteBuild(std::ostream& os,
   std::string assignments = variable_assignments.str();
   const std::string& args = arguments;
   bool useResponseFile = false;
-  if (cmdLineLimit > 0
+  if (cmdLineLimit < 0 || cmdLineLimit > 0
       && args.size() + buildstr.size() + assignments.size()
                                                     > (size_t) cmdLineLimit) {
     variable_assignments.str(std::string());

--- a/Source/cmGlobalNinjaGenerator.h
+++ b/Source/cmGlobalNinjaGenerator.h
@@ -94,7 +94,7 @@ public:
                   const cmNinjaDeps& orderOnlyDeps,
                   const cmNinjaVars& variables,
                   const std::string& rspfile = std::string(),
-                  int cmdLineLimit = -1,
+                  int cmdLineLimit = 0,
                   bool* usedResponseFile = 0);
 
   /**

--- a/Source/cmNinjaNormalTargetGenerator.cxx
+++ b/Source/cmNinjaNormalTargetGenerator.cxx
@@ -369,7 +369,7 @@ cmNinjaNormalTargetGenerator
 }
 
 
-extern int calculateCommandLineLengthLimit(int linkRuleLength)
+static int calculateCommandLineLengthLimit(int linkRuleLength)
 {
   static int const limits[] = {
 #ifdef _WIN32

--- a/Source/cmNinjaNormalTargetGenerator.cxx
+++ b/Source/cmNinjaNormalTargetGenerator.cxx
@@ -369,7 +369,7 @@ cmNinjaNormalTargetGenerator
 }
 
 
-static int calculateCommandLineLengthLimit(int linkRuleLength)
+extern int calculateCommandLineLengthLimit(int linkRuleLength)
 {
   static int const limits[] = {
 #ifdef _WIN32

--- a/Source/cmNinjaNormalTargetGenerator.cxx
+++ b/Source/cmNinjaNormalTargetGenerator.cxx
@@ -698,9 +698,7 @@ void cmNinjaNormalTargetGenerator::WriteLinkStatement()
   cmGlobalNinjaGenerator& globalGen = *this->GetGlobalGenerator();
 
   int commandLineLengthLimit = -1;
-  const char* forceRspFile = "CMAKE_NINJA_FORCE_RESPONSE_FILE";
-  if (!mf->IsDefinitionSet(forceRspFile) &&
-      cmSystemTools::GetEnv(forceRspFile) == 0)
+  if (!this->ForceResponseFile())
     {
     commandLineLengthLimit = calculateCommandLineLengthLimit(
                 globalGen.GetRuleCmdLength(this->LanguageLinkerRule()));

--- a/Source/cmNinjaNormalTargetGenerator.cxx
+++ b/Source/cmNinjaNormalTargetGenerator.cxx
@@ -697,7 +697,7 @@ void cmNinjaNormalTargetGenerator::WriteLinkStatement()
 
   cmGlobalNinjaGenerator& globalGen = *this->GetGlobalGenerator();
 
-  int commandLineLengthLimit = 1;
+  int commandLineLengthLimit = -1;
   const char* forceRspFile = "CMAKE_NINJA_FORCE_RESPONSE_FILE";
   if (!mf->IsDefinitionSet(forceRspFile) &&
       cmSystemTools::GetEnv(forceRspFile) == 0)

--- a/Source/cmNinjaTargetGenerator.cxx
+++ b/Source/cmNinjaTargetGenerator.cxx
@@ -585,8 +585,6 @@ cmNinjaTargetGenerator
   this->GetBuildFileStream() << "\n";
 }
 
-extern int calculateCommandLineLengthLimit(int linkRuleLength);
-
 void
 cmNinjaTargetGenerator
 ::WriteObjectBuildStatement(

--- a/Source/cmNinjaTargetGenerator.h
+++ b/Source/cmNinjaTargetGenerator.h
@@ -152,6 +152,8 @@ protected:
                             cmGeneratorTarget* target,
                             cmNinjaVars& vars);
 
+  bool ForceResponseFile();
+
 private:
   cmLocalNinjaGenerator* LocalGenerator;
   /// List of object files for this target.


### PR DESCRIPTION
In our case we have so many include paths that we hit 32kb limit on Windows, so compiling with Ninja fails. I guess there is a same story with make, will investigate make generator later.

Would be nice to get feedback so I can improve contribution if needed.