### PR TITLE
Updated findgit to match latest github version

### DIFF
--- a/Modules/FindGit.cmake
+++ b/Modules/FindGit.cmake
@@ -43,7 +43,7 @@ set(git_names git eg)
 #
 if(WIN32)
   if(NOT CMAKE_GENERATOR MATCHES "MSYS")
-    set(git_names git.cmd git eg.cmd eg)
+    set(git_names git.cmd git eg.cmd eg git.exe)
     # GitHub search path for Windows
     set(github_path "$ENV{LOCALAPPDATA}/Github/PortableGit*/bin")
     file(GLOB github_path "${github_path}")

--- a/Modules/FindGit.cmake
+++ b/Modules/FindGit.cmake
@@ -45,7 +45,7 @@ if(WIN32)
   if(NOT CMAKE_GENERATOR MATCHES "MSYS")
     set(git_names git.cmd git eg.cmd eg git.exe)
     # GitHub search path for Windows
-    set(github_path "$ENV{LOCALAPPDATA}/Github/PortableGit*/bin")
+    set(github_path "$ENV{LOCALAPPDATA}/Github/PortableGit*/cmd")
     file(GLOB github_path "${github_path}")
     # SourceTree search path for Windows
     set(_git_sourcetree_path "$ENV{LOCALAPPDATA}/Atlassian/SourceTree/git_local/bin")


### PR DESCRIPTION
github_path "$ENV{LOCALAPPDATA}/Github/PortableGit*/bin" is not longer
valid, and the new path should be set to github_path
"$ENV{LOCALAPPDATA}/Github/PortableGit*/cmd"