### PR TITLE
fix FindHDF5: add new debug suffix

### DIFF
--- a/Modules/FindHDF5.cmake
+++ b/Modules/FindHDF5.cmake
@@ -310,10 +310,10 @@ if( NOT HDF5_FOUND )
                 # See https://cmake.org/Bug/view.php?id=1643.  We search
                 # first for the full static library name, but fall back to a
                 # generic search on the name if the static search fails.
-                set( THIS_LIBRARY_SEARCH_DEBUG lib${LIB}d.a ${LIB}d )
+                set( THIS_LIBRARY_SEARCH_DEBUG lib${LIB}d.a ${LIB}d lib${LIB}_debug.a ${LIB}_debug )
                 set( THIS_LIBRARY_SEARCH_RELEASE lib${LIB}.a ${LIB} )
             else()
-                set( THIS_LIBRARY_SEARCH_DEBUG ${LIB}d )
+                set( THIS_LIBRARY_SEARCH_DEBUG ${LIB}d ${LIB}_debug )
                 set( THIS_LIBRARY_SEARCH_RELEASE ${LIB} )
             endif()
             find_library( HDF5_${LIB}_LIBRARY_DEBUG


### PR DESCRIPTION
My install folder of hdf5 (1.8.16) after compilation in debug.

[root@db1cc796f170 Debug]# ls -R hdf5/1.8.16/
```
hdf5/1.8.16/:
bin  include  lib  share

hdf5/1.8.16/bin:
gif2h5  h52gif  h5copy  h5debug  h5diff  h5dump  h5import  h5jam  h5ls  h5mkgrp  h5repack  h5repart  h5stat  h5unjam

hdf5/1.8.16/include:
H5ACpkg.h       H5Attribute.h  H5Cpkg.h       H5DataType.h    H5Epkg.h       H5FDlog.h     H5FSpkg.h       H5Gpkg.h      H5HLpublic.h     H5LTpublic.h  H5OcreatProp.h   H5Ppkg.h      H5Spublic.h     H5api_adpt.h    h5tools_ref.h
H5ACpublic.h    H5B2pkg.h      H5Cpp.h        H5DcreatProp.h  H5Epubgen.h    H5FDmpi.h     H5FSpublic.h    H5Gpublic.h   H5IMpublic.h     H5Library.h   H5Opkg.h         H5Ppublic.h   H5StrType.h     H5overflow.h    h5tools_str.h
H5AbstractDs.h  H5B2public.h   H5CppDoc.h     H5Dpkg.h        H5Epublic.h    H5FDmpio.h    H5FaccProp.h    H5Group.h     H5IdComponent.h  H5Location.h  H5Opublic.h      H5PredType.h  H5TBpublic.h    H5pubconf.h     h5tools_utils.h
H5Alltypes.h    H5Bpkg.h       H5Cpublic.h    H5Dpublic.h     H5Eterm.h      H5FDmulti.h   H5FcreatProp.h  H5HFpkg.h     H5Include.h      H5Lpkg.h      H5Oshared.h      H5PropList.h  H5Tpkg.h        H5public.h      h5trav.h
H5Apkg.h        H5Bpublic.h    H5DOpublic.h   H5DxferProp.h   H5Exception.h  H5FDpkg.h     H5File.h        H5HFpublic.h  H5IntType.h      H5Lpublic.h   H5PLextern.h     H5Rpkg.h      H5Tpublic.h     H5version.h     hdf5.h
H5Apublic.h     H5Classes.h    H5DSpublic.h   H5Edefin.h      H5FDcore.h     H5FDpublic.h  H5FloatType.h   H5HGpkg.h     H5Ipkg.h         H5MMpublic.h  H5PLpublic.h     H5Rpublic.h   H5VarLenType.h  h5diff.h        hdf5_hl.h
H5ArrayType.h   H5CommonFG.h   H5DataSet.h    H5Einit.h       H5FDdirect.h   H5FDsec2.h    H5Fpkg.h        H5HGpublic.h  H5Ipublic.h      H5MPpkg.h     H5PTpublic.h     H5SMpkg.h     H5Zpkg.h        h5tools.h
H5AtomType.h    H5CompType.h   H5DataSpace.h  H5EnumType.h    H5FDfamily.h   H5FDstdio.h   H5Fpublic.h     H5HLpkg.h     H5LTparse.h      H5Object.h    H5PacketTable.h  H5Spkg.h      H5Zpublic.h     h5tools_dump.h

hdf5/1.8.16/lib:
libhdf5.settings      libhdf5_cpp_debug.so.1.8.16  libhdf5_debug.so         libhdf5_hl_cpp_debug.a          libhdf5_hl_cpp_debug.so.10.1.0  libhdf5_hl_debug.so.1.8.16  libhdf5_tools_debug.so
libhdf5_cpp_debug.a   libhdf5_cpp_debug.so.10.1.0  libhdf5_debug.so.1.8.16  libhdf5_hl_cpp_debug.so         libhdf5_hl_debug.a              libhdf5_hl_debug.so.10.1.0  libhdf5_tools_debug.so.1.8.16
libhdf5_cpp_debug.so  libhdf5_debug.a              libhdf5_debug.so.10.1.0  libhdf5_hl_cpp_debug.so.1.8.16  libhdf5_hl_debug.so             libhdf5_tools_debug.a       libhdf5_tools_debug.so.10.1.0

hdf5/1.8.16/share:
COPYING  RELEASE.txt  USING_HDF5_CMake.txt  cmake

hdf5/1.8.16/share/cmake:
FindHDF5.cmake  hdf5-config-version.cmake  hdf5-config.cmake  hdf5-targets-debug.cmake  hdf5-targets.cmake
```