### PR TITLE
ExternalProject: Fix git stash not using "--all" option

### DIFF
--- a/Modules/ExternalProject.cmake
+++ b/Modules/ExternalProject.cmake
@@ -2021,6 +2021,8 @@ function(_ep_add_update_command name)
       --non-interactive ${svn_trust_cert_args} ${svn_user_pw_args})
     set(always 1)
   elseif(git_repository)
+    unset(CMAKE_MODULE_PATH) # Use CMake builtin find module
+    find_package(Git QUIET)
     if(NOT GIT_EXECUTABLE)
       message(FATAL_ERROR "error: could not find git for fetch of ${name}")
     endif()


### PR DESCRIPTION
`GIT_VERSION_STRING` is unset in `_ep_write_gitupdate_script()`, hence git stash is not being called with the `--all` option, even if Git is new enough to support this.

I've found this issue while tracking down the following error that appeared in an external project using git with untracked files.

```
No stash found.
CMake Error at ...tmp/...-gitupdate.cmake:136 (message):
  Failed to unstash changes in: '...'.
  You will have to resolve the conflicts manually
```

Without `--all` the repo apears dirty and the generated `-gitupdate.cmake` tries to stash files which fails.