### PR TITLE
Append a library search path found in official Windows prebuilt binaries

### DIFF
--- a/Modules/FindBoost.cmake
+++ b/Modules/FindBoost.cmake
@@ -209,6 +209,7 @@
 # Copyright 2007      Mike Jackson
 # Copyright 2008      Andreas Pakulat <apaku@gmx.de>
 # Copyright 2008-2012 Philip Lowman <philip@yhbt.com>
+# Copyright 2016 Alex Turbov <i.zaufi@gmail.com>
 #
 # Distributed under the OSI-approved BSD License (the "License");
 # see accompanying file Copyright.txt for details.
@@ -862,6 +863,37 @@ function(_Boost_MISSING_DEPENDENCIES componentvar extravar)
 endfunction()
 
 #
+# Update library search directory hint variable with paths used by prebuilt boost binaries.
+#
+# Prebuilt windows binaries (https://sourceforge.net/projects/boost/files/boost-binaries/)
+# have library directories named using MSVC compiler version and architecture.
+# This function would append corresponding directories if MSVS is a current compiler,
+# so having Boost_ROOT would be enough to specify to find everything.
+#
+macro(_Boost_UPDATE_LIBRARY_SEARCH_DIRS_WITH_PREBUILD_PATHS componentlibvar basedir)
+  if(MSVC)
+    if(CMAKE_CL_64)
+      set(_arch_suffix 64)
+    else()
+      set(_arch_suffix 32)
+    endif()
+    if(MSVC80)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-8.0)
+    elseif(MSVC90)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-9.0)
+    elseif(MSVC10)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-10.0)
+    elseif(MSVC11)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-11.0)
+    elseif(MSVC12)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-12.0)
+    elseif(MSVC14)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-14.0)
+    endif()
+  endif()
+endmacro()
+
+#
 # End functions/macros
 #
 #-------------------------------------------------------------------------------
@@ -1319,8 +1351,10 @@ foreach(c DEBUG RELEASE)
 
     if(BOOST_ROOT)
       list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} ${BOOST_ROOT}/lib ${BOOST_ROOT}/stage/lib)
+      _Boost_UPDATE_LIBRARY_SEARCH_DIRS_WITH_PREBUILD_PATHS(_boost_LIBRARY_SEARCH_DIRS_${c} BOOST_ROOT)
     elseif(_ENV_BOOST_ROOT)
       list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c} ${_ENV_BOOST_ROOT}/lib ${_ENV_BOOST_ROOT}/stage/lib)
+      _Boost_UPDATE_LIBRARY_SEARCH_DIRS_WITH_PREBUILD_PATHS(_boost_LIBRARY_SEARCH_DIRS_${c} _ENV_BOOST_ROOT)
     endif()
 
     list(APPEND _boost_LIBRARY_SEARCH_DIRS_${c}

--- a/Modules/FindBoost.cmake
+++ b/Modules/FindBoost.cmake
@@ -443,24 +443,26 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
     endif()
   elseif (GHSMULTI)
     set(_boost_COMPILER "-ghs")
-  elseif (MSVC14)
-    set(_boost_COMPILER "-vc140")
-  elseif (MSVC12)
-    set(_boost_COMPILER "-vc120")
-  elseif (MSVC11)
-    set(_boost_COMPILER "-vc110")
-  elseif (MSVC10)
-    set(_boost_COMPILER "-vc100")
-  elseif (MSVC90)
-    set(_boost_COMPILER "-vc90")
-  elseif (MSVC80)
-    set(_boost_COMPILER "-vc80")
-  elseif (MSVC71)
-    set(_boost_COMPILER "-vc71")
-  elseif (MSVC70) # Good luck!
-    set(_boost_COMPILER "-vc7") # yes, this is correct
-  elseif (MSVC60) # Good luck!
-    set(_boost_COMPILER "-vc6") # yes, this is correct
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19)
+      set(_boost_COMPILER "-vc140")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
+      set(_boost_COMPILER "-vc120")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)
+      set(_boost_COMPILER "-vc110")
+    elseif (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+      set(_boost_COMPILER "-vc100")
+    elseif (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15)
+      set(_boost_COMPILER "-vc90")
+    elseif (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+      set(_boost_COMPILER "-vc80")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.10)
+      set(_boost_COMPILER "-vc71")
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13) # Good luck!
+      set(_boost_COMPILER "-vc7") # yes, this is correct
+    elseif() # MSVC60 Good luck!
+      set(_boost_COMPILER "-vc6") # yes, this is correct
+    endif()
   elseif (BORLAND)
     set(_boost_COMPILER "-bcb")
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
@@ -1293,7 +1295,8 @@ endif()
 #  g        using debug versions of the standard and runtime
 #           support libraries
 if(WIN32 AND Boost_USE_DEBUG_RUNTIME)
-  if(MSVC OR "${CMAKE_CXX_COMPILER}" MATCHES "icl"
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
+          OR "${CMAKE_CXX_COMPILER}" MATCHES "icl"
           OR "${CMAKE_CXX_COMPILER}" MATCHES "icpc")
     set(_boost_DEBUG_ABI_TAG "${_boost_DEBUG_ABI_TAG}g")
   endif()

--- a/Modules/FindBoost.cmake
+++ b/Modules/FindBoost.cmake
@@ -209,7 +209,7 @@
 # Copyright 2007      Mike Jackson
 # Copyright 2008      Andreas Pakulat <apaku@gmx.de>
 # Copyright 2008-2012 Philip Lowman <philip@yhbt.com>
-# Copyright 2016 Alex Turbov <i.zaufi@gmail.com>
+# Copyright 2016      Alex Turbov <i.zaufi@gmail.com>
 #
 # Distributed under the OSI-approved BSD License (the "License");
 # see accompanying file Copyright.txt for details.
@@ -870,27 +870,27 @@ endfunction()
 # Prebuilt windows binaries (https://sourceforge.net/projects/boost/files/boost-binaries/)
 # have library directories named using MSVC compiler version and architecture.
 # This function would append corresponding directories if MSVS is a current compiler,
-# so having Boost_ROOT would be enough to specify to find everything.
+# so having `BOOST_ROOT` would be enough to specify to find everything.
 #
 macro(_Boost_UPDATE_LIBRARY_SEARCH_DIRS_WITH_PREBUILD_PATHS componentlibvar basedir)
-  if(MSVC)
-    if(CMAKE_CL_64)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
       set(_arch_suffix 64)
     else()
       set(_arch_suffix 32)
     endif()
-    if(MSVC80)
-      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-8.0)
-    elseif(MSVC90)
-      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-9.0)
-    elseif(MSVC10)
-      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-10.0)
-    elseif(MSVC11)
-      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-11.0)
-    elseif(MSVC12)
-      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-12.0)
-    elseif(MSVC14)
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19)
       list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-14.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-12.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-11.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-10.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-9.0)
+    elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+      list(APPEND ${componentlibvar} ${${basedir}}/lib${_arch_suffix}-msvc-8.0)
     endif()
   endif()
 endmacro()

--- a/Modules/FindBoost.cmake
+++ b/Modules/FindBoost.cmake
@@ -460,7 +460,7 @@ function(_Boost_GUESS_COMPILER_PREFIX _ret)
       set(_boost_COMPILER "-vc71")
     elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13) # Good luck!
       set(_boost_COMPILER "-vc7") # yes, this is correct
-    elseif() # MSVC60 Good luck!
+    else() # MSVC60 Good luck!
       set(_boost_COMPILER "-vc6") # yes, this is correct
     endif()
   elseif (BORLAND)


### PR DESCRIPTION
So you don't need to specify `BOOST_LIBRARYDIR` along with `BOOST_ROOT` provided.
See also: https://sourceforge.net/projects/boost/files/boost-binaries/