### PR TITLE
Added support for user-configurable PBXBuildFile attributes and mig files.

### DIFF
--- a/Help/manual/cmake-properties.7.rst
+++ b/Help/manual/cmake-properties.7.rst
@@ -344,6 +344,7 @@ Properties on Source Files
    /prop_sf/VS_XAML_TYPE
    /prop_sf/WRAP_EXCLUDE
    /prop_sf/XCODE_EXPLICIT_FILE_TYPE
+   /prop_sf/XCODE_FILE_ATTRIBUTES
    /prop_sf/XCODE_LAST_KNOWN_FILE_TYPE
 
 .. _`Cache Entry Properties`:

--- a/Help/prop_sf/XCODE_FILE_ATTRIBUTES.rst
+++ b/Help/prop_sf/XCODE_FILE_ATTRIBUTES.rst
@@ -1,0 +1,11 @@
+XCODE_FILE_ATTRIBUTES
+---------------------
+
+Add values to the Xcode ``ATTRIBUTES`` setting on its reference to a
+source file.  Among other things, this can be used to set the role on
+a mig file::
+
+  set_source_files_properties(defs.mig
+      PROPERTIES
+          XCODE_FILE_ATTRIBUTES "Client;Server"
+  )

--- a/Source/cmGlobalXCodeGenerator.cxx
+++ b/Source/cmGlobalXCodeGenerator.cxx
@@ -689,7 +689,9 @@ cmXCodeObject* cmGlobalXCodeGenerator::CreateXCodeSourceFile(
   cmXCodeObject* fileRef = buildFile->GetObject("fileRef")->GetObject();
 
   cmXCodeObject* settings = this->CreateObject(cmXCodeObject::ATTRIBUTE_GROUP);
-  settings->AddAttribute("COMPILER_FLAGS", this->CreateString(flags));
+  if (!flags.empty()) {
+    settings->AddAttribute("COMPILER_FLAGS", this->CreateString(flags));
+  }
 
   // Is this a resource file in this target? Add it to the resources group...
   //
@@ -698,21 +700,23 @@ cmXCodeObject* cmGlobalXCodeGenerator::CreateXCodeSourceFile(
     gtgt->GetTargetSourceFileFlags(sf);
   bool isResource = tsFlags.Type == cmGeneratorTarget::SourceFileTypeResource;
 
+  cmXCodeObject* attrs = this->CreateObject(cmXCodeObject::OBJECT_LIST);
+
   // Is this a "private" or "public" framework header file?
   // Set the ATTRIBUTES attribute appropriately...
   //
   if (gtgt->IsFrameworkOnApple()) {
     if (tsFlags.Type == cmGeneratorTarget::SourceFileTypePrivateHeader) {
-      cmXCodeObject* attrs = this->CreateObject(cmXCodeObject::OBJECT_LIST);
       attrs->AddObject(this->CreateString("Private"));
-      settings->AddAttribute("ATTRIBUTES", attrs);
       isResource = true;
     } else if (tsFlags.Type == cmGeneratorTarget::SourceFileTypePublicHeader) {
-      cmXCodeObject* attrs = this->CreateObject(cmXCodeObject::OBJECT_LIST);
       attrs->AddObject(this->CreateString("Public"));
-      settings->AddAttribute("ATTRIBUTES", attrs);
       isResource = true;
     }
+  }
+
+  if (attrs->CountObjects() != 0) {
+    settings->AddAttribute("ATTRIBUTES", attrs);
   }
 
   // Add the fileRef to the top level Resources group/folder if it is not
@@ -723,7 +727,9 @@ cmXCodeObject* cmGlobalXCodeGenerator::CreateXCodeSourceFile(
     this->ResourcesGroupChildren->AddObject(fileRef);
   }
 
-  buildFile->AddAttribute("settings", settings);
+  if (settings->CountAttributes() != 0) {
+    buildFile->AddAttribute("settings", settings);
+  }
   return buildFile;
 }
 

--- a/Source/cmGlobalXCodeGenerator.cxx
+++ b/Source/cmGlobalXCodeGenerator.cxx
@@ -715,6 +715,20 @@ cmXCodeObject* cmGlobalXCodeGenerator::CreateXCodeSourceFile(
     }
   }
 
+  // Add user-specified file attributes.
+  const char* attrs_list = sf->GetProperty("XCODE_FILE_ATTRIBUTES");
+  if (attrs_list) {
+    // Expand the list of attributes.
+    std::vector<std::string> attributes;
+    cmSystemTools::ExpandListArgument(attrs_list, attributes);
+
+    // Store the attributes.
+    for (std::vector<std::string>::const_iterator ai = attributes.begin();
+         ai != attributes.end(); ++ai) {
+      attrs->AddObject(this->CreateString(*ai));
+    }
+  }
+
   if (attrs->CountObjects() != 0) {
     settings->AddAttribute("ATTRIBUTES", attrs);
   }

--- a/Source/cmGlobalXCodeGenerator.cxx
+++ b/Source/cmGlobalXCodeGenerator.cxx
@@ -315,6 +315,10 @@ void cmGlobalXCodeGenerator::GenerateBuildCommand(
 ///! Create a local generator appropriate to this Global Generator
 cmLocalGenerator* cmGlobalXCodeGenerator::CreateLocalGenerator(cmMakefile* mf)
 {
+  // Default handling for mig files.
+  mf->AddDefinition("CMAKE_MIG_SOURCE_FILE_EXTENSIONS", "mig");
+  FillExtensionToLanguageMap("MIG", mf);
+
   return new cmLocalXCodeGenerator(this, mf);
 }
 
@@ -792,6 +796,8 @@ std::string GetSourcecodeValueFromFileExtension(const std::string& _ext,
     sourcecode += ".asm";
   } else if (ext == "metal") {
     sourcecode += ".metal";
+  } else if (ext == "mig") {
+    sourcecode += ".mig";
   }
   // else
   //  {

--- a/Source/cmXCodeObject.h
+++ b/Source/cmXCodeObject.h
@@ -59,11 +59,11 @@ public:
   static const char* PBXTypeNames[];
   virtual ~cmXCodeObject();
   cmXCodeObject(PBXType ptype, Type type);
-  Type GetType() { return this->TypeValue; }
-  PBXType GetIsA() { return this->IsA; }
+  Type GetType() const { return this->TypeValue; }
+  PBXType GetIsA() const { return this->IsA; }
 
   void SetString(const std::string& s);
-  const std::string& GetString() { return this->String; }
+  const std::string& GetString() const { return this->String; }
 
   void AddAttribute(const std::string& name, cmXCodeObject* value)
   {
@@ -73,7 +73,7 @@ public:
   void SetObject(cmXCodeObject* value) { this->Object = value; }
   cmXCodeObject* GetObject() { return this->Object; }
   void AddObject(cmXCodeObject* value) { this->List.push_back(value); }
-  bool HasObject(cmXCodeObject* o)
+  bool HasObject(cmXCodeObject* o) const
   {
     return !(std::find(this->List.begin(), this->List.end(), o) ==
              this->List.end());
@@ -94,23 +94,25 @@ public:
   virtual void PrintComment(std::ostream&) {}
 
   static void PrintList(std::vector<cmXCodeObject*> const&, std::ostream& out);
-  const std::string& GetId() { return this->Id; }
+  const std::string& GetId() const { return this->Id; }
   void SetId(const std::string& id) { this->Id = id; }
-  cmGeneratorTarget* GetTarget() { return this->Target; }
+  cmGeneratorTarget* GetTarget() const { return this->Target; }
   void SetTarget(cmGeneratorTarget* t) { this->Target = t; }
-  const std::string& GetComment() { return this->Comment; }
-  bool HasComment() { return (!this->Comment.empty()); }
-  cmXCodeObject* GetObject(const char* name)
+  const std::string& GetComment() const { return this->Comment; }
+  bool HasComment() const { return (!this->Comment.empty()); }
+  cmXCodeObject* GetObject(const char* name) const
   {
-    if (this->ObjectAttributes.count(name)) {
-      return this->ObjectAttributes[name];
+    std::map<std::string, cmXCodeObject*>::const_iterator i =
+        this->ObjectAttributes.find(name);
+    if (i != this->ObjectAttributes.end()) {
+      return i->second;
     }
     return 0;
   }
   // search the attribute list for an object of the specified type
-  cmXCodeObject* GetObject(cmXCodeObject::PBXType t)
+  cmXCodeObject* GetObject(cmXCodeObject::PBXType t) const
   {
-    for (std::vector<cmXCodeObject*>::iterator i = this->List.begin();
+    for (std::vector<cmXCodeObject*>::const_iterator i = this->List.begin();
          i != this->List.end(); ++i) {
       cmXCodeObject* o = *i;
       if (o->IsA == t) {
@@ -126,7 +128,7 @@ public:
   {
     this->DependLibraries[configName].push_back(l);
   }
-  std::map<std::string, StringVec> const& GetDependLibraries()
+  std::map<std::string, StringVec> const& GetDependLibraries() const
   {
     return this->DependLibraries;
   }
@@ -134,11 +136,11 @@ public:
   {
     this->DependTargets[configName].push_back(tName);
   }
-  std::map<std::string, StringVec> const& GetDependTargets()
+  std::map<std::string, StringVec> const& GetDependTargets() const
   {
     return this->DependTargets;
   }
-  std::vector<cmXCodeObject*> const& GetObjectList() { return this->List; }
+  std::vector<cmXCodeObject*> const& GetObjectList() const { return this->List; }
   void SetComment(const std::string& c) { this->Comment = c; }
   static void PrintString(std::ostream& os, std::string String);
 

--- a/Source/cmXCodeObject.h
+++ b/Source/cmXCodeObject.h
@@ -122,6 +122,9 @@ public:
     return 0;
   }
 
+  std::size_t CountAttributes() const { return this->ObjectAttributes.size(); }
+  std::size_t CountObjects() const { return this->List.size(); }
+
   void CopyAttributes(cmXCodeObject*);
 
   void AddDependLibrary(const std::string& configName, const std::string& l)


### PR DESCRIPTION
Updated the Xcode back-end so that the following lines:
```
set_source_files_properties(defs.mig
    PROPERTIES
        XCODE_FILE_ATTRIBUTES "Client;Server"
)
```
...produce the following output:
```
CC05C50A647749C2A8CBD7FA /* /path/to/defs.mig */ = {isa = PBXBuildFile; fileRef = A98241779C4D44C78764B9A3 /* /path-to-defs.mig */; settings = {ATTRIBUTES = (Client,Server); }; };
```

Additionally, the Xcode back-end now provides default support for mig files, leveraging Xcode's built-in behavior.