### PR TITLE
The "/Os" compiler flag does not map to "<Optimization>MinSize</Optimization>"

### DIFF
--- a/Source/cmVS14CLFlagTable.h
+++ b/Source/cmVS14CLFlagTable.h
@@ -16,7 +16,6 @@ static cmVS7FlagTable cmVS14CLFlagTable[] = {
 
   { "Optimization", "", "Custom", "Custom", 0 },
   { "Optimization", "Od", "Disabled", "Disabled", 0 },
-  { "Optimization", "Os", "Minimize Size", "MinSize", 0 },
   { "Optimization", "O1", "Minimize Size", "MinSpace", 0 },
   { "Optimization", "O2", "Maximize Speed", "MaxSpeed", 0 },
   { "Optimization", "Ox", "Full Optimization", "Full", 0 },


### PR DESCRIPTION
Instead it maps to "\<FavorSizeOrSpeed\>Size\</FavorSizeOrSpeed\>", as already defined in this file.

I'm currently getting the following errors from MSBuild (14.0.25123.0) when using the "/Os" flag with CMake:

    C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\Microsoft.CppCommon.targets(356,5): error : Element <Optimization> has an invalid value of "MinSize".

After manually fixing the optimization settings in Visual Studio, I can see the *.vcxproj file contains the following:

    <ClCompile>
        ...
        <Optimization>Full</Optimization>
        ...
        <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
    </ClCompile>

It looks like commit 2c2ec4883bd9829b3589ce0aebe466bae9e8b0e9 broke this.