### PR TITLE
[AIX][Clang] Add Clang on AIX support

### DIFF
--- a/Modules/Platform/AIX-Clang-C.cmake
+++ b/Modules/Platform/AIX-Clang-C.cmake
@@ -1,0 +1,1 @@
+include(Platform/AIX-GNU-C)

--- a/Modules/Platform/AIX-Clang-CXX.cmake
+++ b/Modules/Platform/AIX-Clang-CXX.cmake
@@ -1,0 +1,1 @@
+include(Platform/AIX-GNU-CXX)


### PR DESCRIPTION
Currently, CMake doesn't support Clang on AIX. So, if we use Clang on AIX, we will meet error like this:

-- The C compiler identification is Clang 3.9.0
-- The CXX compiler identification is Clang 3.9.0
-- Check for working C compiler: clang
-- Check for working C compiler: clang -- broken
CMake Error at /opt/freeware/share/cmake/Modules/CMakeTestCCompiler.cmake:61 (message):
  ...
  /usr/bin/clang
  CMakeFiles/cmTryCompileExec642976823.dir/testCCompiler.c.o -o
  cmTryCompileExec642976823 /opt/freeware/lib /usr/lib /lib

  ld: 0711-168 SEVERE ERROR: Input file: /opt/freeware/lib

        Input files must be regular files.

The reason is our CMake doesn't consider Clang on AIX platform, we should support it to make Clang on AiX work.