### PR TITLE
ninja: Have the bundle resources be a dependency of their target

### DIFF
--- a/Source/cmNinjaNormalTargetGenerator.cxx
+++ b/Source/cmNinjaNormalTargetGenerator.cxx
@@ -61,6 +61,7 @@ cmNinjaNormalTargetGenerator::cmNinjaNormalTargetGenerator(
   this->OSXBundleGenerator =
     new cmOSXBundleGenerator(target, this->GetConfigName());
   this->OSXBundleGenerator->SetMacContentFolders(&this->MacContentFolders);
+  this->MacOSXContentGenerator->SetOSXBundleGenerator(this->OSXBundleGenerator);
 }
 
 cmNinjaNormalTargetGenerator::~cmNinjaNormalTargetGenerator()

--- a/Source/cmNinjaTargetGenerator.cxx
+++ b/Source/cmNinjaTargetGenerator.cxx
@@ -487,6 +487,10 @@ void cmNinjaTargetGenerator::WriteObjectBuildStatements()
   this->GetLocalGenerator()->AppendTargetDepends(this->GeneratorTarget,
                                                  orderOnlyDeps);
 
+  cmNinjaDeps bundleDeps;
+  this->OSXBundleGenerator->GetOutputs(bundleDeps);
+  orderOnlyDeps.insert(orderOnlyDeps.end(), bundleDeps.begin(), bundleDeps.end());
+
   // Add order-only dependencies on custom command outputs.
   for (std::vector<cmCustomCommand const*>::const_iterator cci =
          this->CustomCommands.begin();
@@ -717,8 +721,8 @@ void cmNinjaTargetGenerator::MacOSXContentGeneratorType::operator()(
   this->Generator->GetGlobalGenerator()->WriteMacOSXContentBuild(input,
                                                                  output);
 
-  // Add as a dependency of all target so that it gets called.
-  this->Generator->GetGlobalGenerator()->AddDependencyToAll(output);
+  // Add as a dependency to the target so that it gets called.
+  this->OSXBundleGenerator->AddOutput(output);
 }
 
 void cmNinjaTargetGenerator::addPoolNinjaVariable(

--- a/Source/cmNinjaTargetGenerator.h
+++ b/Source/cmNinjaTargetGenerator.h
@@ -130,14 +130,21 @@ protected:
     : cmOSXBundleGenerator::MacOSXContentGeneratorType
   {
     MacOSXContentGeneratorType(cmNinjaTargetGenerator* g)
-      : Generator(g)
+      : Generator(g),
+        OSXBundleGenerator(0)
     {
     }
 
     void operator()(cmSourceFile const& source, const char* pkgloc);
 
+    void SetOSXBundleGenerator(cmOSXBundleGenerator* generator)
+    {
+      OSXBundleGenerator = generator;
+    }
+
   private:
     cmNinjaTargetGenerator* Generator;
+    cmOSXBundleGenerator* OSXBundleGenerator;
   };
   friend struct MacOSXContentGeneratorType;
 

--- a/Source/cmOSXBundleGenerator.h
+++ b/Source/cmOSXBundleGenerator.h
@@ -18,6 +18,7 @@
 
 #include <set>
 #include <string>
+#include <vector>
 
 class cmTarget;
 class cmMakefile;
@@ -57,6 +58,16 @@ public:
     this->MacContentFolders = macContentFolders;
   }
 
+  void AddOutput(const std::string& output)
+  {
+    this->Outputs.push_back(output);
+  }
+
+  void GetOutputs(std::vector<std::string>& outputs)
+  {
+    outputs = Outputs;
+  }
+
 private:
   bool MustSkip();
 
@@ -66,6 +77,7 @@ private:
   cmLocalGenerator* LocalGenerator;
   std::string ConfigName;
   std::set<std::string>* MacContentFolders;
+  std::vector<std::string> Outputs;
 };
 
 #endif


### PR DESCRIPTION
Bundle resources were added to the "all" target which made it really hard to have OSX bundle resources copied when generating a specific target.
This change adds a dependency on the resources to the target using them.