### PR TITLE
ninja: Have the bundle resources be a dependency of their target

### DIFF
--- a/Source/cmNinjaTargetGenerator.cxx
+++ b/Source/cmNinjaTargetGenerator.cxx
@@ -487,6 +487,8 @@ void cmNinjaTargetGenerator::WriteObjectBuildStatements()
   this->GetLocalGenerator()->AppendTargetDepends(this->GeneratorTarget,
                                                  orderOnlyDeps);
 
+  orderOnlyDeps.insert(orderOnlyDeps.end(), ExtraFiles.begin(), ExtraFiles.end());
+
   // Add order-only dependencies on custom command outputs.
   for (std::vector<cmCustomCommand const*>::const_iterator cci =
          this->CustomCommands.begin();
@@ -717,8 +719,8 @@ void cmNinjaTargetGenerator::MacOSXContentGeneratorType::operator()(
   this->Generator->GetGlobalGenerator()->WriteMacOSXContentBuild(input,
                                                                  output);
 
-  // Add as a dependency of all target so that it gets called.
-  this->Generator->GetGlobalGenerator()->AddDependencyToAll(output);
+  // Add as a dependency to the target so that it gets called.
+  this->Generator->ExtraFiles.push_back(output);
 }
 
 void cmNinjaTargetGenerator::addPoolNinjaVariable(

--- a/Source/cmNinjaTargetGenerator.h
+++ b/Source/cmNinjaTargetGenerator.h
@@ -156,6 +156,7 @@ private:
   /// List of object files for this target.
   cmNinjaDeps Objects;
   std::vector<cmCustomCommand const*> CustomCommands;
+  cmNinjaDeps ExtraFiles;
 };
 
 #endif // ! cmNinjaTargetGenerator_h


### PR DESCRIPTION
Bundle resources were added to the "all" target which made it really hard to have OSX bundle resources copied when generating a specific target.
This change adds a dependency on the resources to the target using them.