### PR TITLE
FindJNI: Fix support for Ubuntu

### DIFF
--- a/Modules/FindJNI.cmake
+++ b/Modules/FindJNI.cmake
@@ -151,13 +151,14 @@ JAVA_APPEND_LIBRARY_DIRECTORIES(JAVA_AWT_LIBRARY_DIRECTORIES
   /usr/lib/jvm/java-6-sun-1.6.0.00/jre/lib/{libarch}       # can this one be removed according to #8821 ? Alex
   /usr/lib/jvm/java-6-openjdk/jre/lib/{libarch}
   /usr/lib/jvm/java-1.6.0-openjdk-1.6.0.0/jre/lib/{libarch}        # fedora
-  /usr/lib/jvm/java-8-openjdk-{libarch}/lib/{libarch}              # ubuntu 15.10
-  /usr/lib/jvm/java-7-openjdk-{libarch}/lib/{libarch}              # ubuntu 15.10
-  /usr/lib/jvm/java-6-openjdk-{libarch}/lib/{libarch}              # ubuntu 15.10
   # Debian specific paths for default JVM
   /usr/lib/jvm/default-java/jre/lib/{libarch}
   /usr/lib/jvm/default-java/jre/lib
   /usr/lib/jvm/default-java/lib
+  # Ubuntu specific paths for default JVM
+  /usr/lib/jvm/java-8-openjdk-{libarch}/jre/lib/{libarch}     # Ubuntu 15.10
+  /usr/lib/jvm/java-7-openjdk-{libarch}/jre/lib/{libarch}     # Ubuntu 15.10
+  /usr/lib/jvm/java-6-openjdk-{libarch}/jre/lib/{libarch}     # Ubuntu 15.10
   # OpenBSD specific paths for default JVM
   /usr/local/jdk-1.7.0/jre/lib/{libarch}
   /usr/local/jre-1.7.0/lib/{libarch}

--- a/Modules/FindJNI.cmake
+++ b/Modules/FindJNI.cmake
@@ -36,7 +36,7 @@
 #  License text for the above reference.)
 
 # Expand {libarch} occurences to java_libarch subdirectory(-ies) and set ${_var}
-macro(java_append_library_directories _var)
+macro(JAVA_APPEND_LIBRARY_DIRECTORIES _var)
     # Determine java arch-specific library subdir
     # Mostly based on openjdk/jdk/make/common/shared/Platform.gmk as of openjdk
     # 1.6.0_18 + icedtea patches. However, it would be much better to base the
@@ -312,8 +312,11 @@ else()
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(JNI  DEFAULT_MSG  JAVA_AWT_LIBRARY JAVA_JVM_LIBRARY
-                                                    JAVA_INCLUDE_PATH  JAVA_INCLUDE_PATH2 JAVA_AWT_INCLUDE_PATH)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(JNI  DEFAULT_MSG  JAVA_AWT_LIBRARY
+                                                    JAVA_JVM_LIBRARY
+                                                    JAVA_INCLUDE_PATH
+                                                    JAVA_INCLUDE_PATH2
+                                                    JAVA_AWT_INCLUDE_PATH)
 
 mark_as_advanced(
   JAVA_AWT_LIBRARY


### PR DESCRIPTION
My previous contribution was buggy.
This commit provide the correct directories for Ubuntu-based distribution in order to find all neccessary libraries.
The pull request proposes also a tiny clean-up commit. 