### PR TITLE
Add missed fallback variable for CPACK_RPM_FILE_NAME

### DIFF
--- a/Modules/CPackRPM.cmake
+++ b/Modules/CPackRPM.cmake
@@ -1803,6 +1803,7 @@ function(cpack_rpm_generate_package)
   endif()
 
   cpack_rpm_variable_fallback("CPACK_RPM_FILE_NAME"
+    "CPACK_RPM_${CPACK_RPM_PACKAGE_COMPONENT}_FILE_NAME"
     "CPACK_RPM_${CPACK_RPM_PACKAGE_COMPONENT_UPPER}_FILE_NAME"
     "CPACK_RPM_FILE_NAME")
   if(NOT CPACK_RPM_FILE_NAME STREQUAL "RPM-DEFAULT")


### PR DESCRIPTION
When set `CPACK_RPM_FILE_NAME` CMake 3.6.0 has missed non uppercased version of `CPACK_RPM_<COMPONENT>_FILE_NAME`.