### PR TITLE
cmake-mode.el: Fix Compilation warning

### DIFF
--- a/Auxiliary/cmake-mode.el
+++ b/Auxiliary/cmake-mode.el
@@ -271,7 +271,7 @@ optional argument topic will be appended to the argument list."
     (save-selected-window
       (select-window (display-buffer buffer 'not-this-window))
       (cmake-mode)
-      (toggle-read-only t))
+      (read-only-mode 1))
     )
   )
 

--- a/Auxiliary/cmake-mode.el
+++ b/Auxiliary/cmake-mode.el
@@ -114,6 +114,14 @@ set the path with these commands:
 ;------------------------------------------------------------------------------
 
 ;;
+;; Indentation increment.
+;;
+(defcustom cmake-tab-width 2
+  "Number of columns to indent cmake blocks"
+  :type 'integer
+  :group 'cmake)
+
+;;
 ;; Line indentation function.
 ;;
 (defun cmake-indent ()
@@ -224,13 +232,6 @@ the indentation.  Otherwise it retains the same position on the line"
 ;; User hook entry point.
 ;;
 (defvar cmake-mode-hook nil)
-
-;;
-;; Indentation increment.
-;;
-(defcustom cmake-tab-width 2
-  "Number of columns to indent cmake blocks"
-  :type 'integer)
 
 ;------------------------------------------------------------------------------
 


### PR DESCRIPTION
Currently when installing latest cmake-mode in Emacs, you get the following warnings:

````
$ emacs -Q -batch -L . -f byte-compile-file
Byte compile file: cmake-mode.el

In cmake-indent:
cmake-mode.el:141:48:Warning: reference to free variable `cmake-tab-width'
cmake-mode.el:231:1:Warning: defcustom for `cmake-tab-width' fails to specify
    containing group
cmake-mode.el:231:1:Warning: defcustom for `cmake-tab-width' fails to specify
    containing group

In cmake-command-run:
cmake-mode.el:274:8:Warning: `toggle-read-only' is an obsolete function (as of
    24.3); use `read-only-mode' instead.
Wrote d:/Git/CMake/Auxiliary/cmake-mode.elc
````

These are caused by actual errors, incorrect declaration order and use of obsolete functions.

With this patch there are no compilation warnings:

````
$ emacs -Q -batch -L . -f byte-compile-file
Byte compile file: cmake-mode.el
Wrote d:/Git/CMake/Auxiliary/cmake-mode.elc
````
