### PR TITLE
Minor editorial changes

### DIFF
--- a/Help/command/separate_arguments.rst
+++ b/Help/command/separate_arguments.rst
@@ -13,19 +13,19 @@ entire command line must be given in one "<args>" argument.
 
 The ``UNIX_COMMAND`` mode separates arguments by unquoted whitespace.  It
 recognizes both single-quote and double-quote pairs.  A backslash
-escapes the next literal character (\" is "); there are no special
-escapes (\n is just n).
+escapes the next literal character (\\" is "); there are no special
+escapes (\\n is just n).
 
 The ``WINDOWS_COMMAND`` mode parses a windows command-line using the same
 syntax the runtime library uses to construct argv at startup.  It
 separates arguments by whitespace that is not double-quoted.
 Backslashes are literal unless they precede double-quotes.  See the
-MSDN article "Parsing C Command-Line Arguments" for details.
+MSDN article "`Parsing C Command-Line Arguments <https://msdn.microsoft.com/library/a1y7w461.aspx>`_" for details.
 
 ::
 
-  separate_arguments(VARIABLE)
+  separate_arguments(<var>)
 
-Convert the value of ``VARIABLE`` to a semi-colon separated list.  All
+Convert the value of ``<var>`` to a semi-colon separated list.  All
 spaces are replaced with ';'.  This helps with generating command
 lines.


### PR DESCRIPTION
Escaped backslashes to make them visible in the text.
Renamed VARIABLE to \<var\> in second signature for consistency with the first signature.
Added link to referenced MSDN documentation.