### PR TITLE
[CPack] Generate checksum file with selected algorithm

### DIFF
--- a/Modules/CPack.cmake
+++ b/Modules/CPack.cmake
@@ -116,6 +116,15 @@
 #  A branding image that will be displayed inside the installer (used by GUI
 #  installers).
 #
+# .. variable:: CPACK_PACKAGE_CHECKSUM
+#
+#  An algorithm that will be used to generate additional file with checksum
+#  of the package. Output file name will be::
+#
+#     ${CPACK_PACKAGE_FILE_NAME}.${CPACK_PACKAGE_CHECKSUM}
+#
+#  Current supported alogorithms: MD5|SHA1|SHA224|SHA256|SHA384|SHA512.
+#
 # .. variable:: CPACK_PROJECT_CONFIG_FILE
 #
 #  CPack-time project CPack configuration file. This file included at cpack

--- a/Source/CPack/cmCPackGenerator.cxx
+++ b/Source/CPack/cmCPackGenerator.cxx
@@ -14,6 +14,7 @@
 
 #include "cmCPackComponentGroup.h"
 #include "cmCPackLog.h"
+#include "cmCryptoHash.h"
 #include "cmGeneratedFileStream.h"
 #include "cmGlobalGenerator.h"
 #include "cmMakefile.h"
@@ -162,6 +163,14 @@ int cmCPackGenerator::PrepareNames()
       "CPACK_PACKAGE_DESCRIPTION or CPACK_PACKAGE_DESCRIPTION_FILE."
         << std::endl);
     return 0;
+  }
+  const char* algoSignature = this->GetOption("CPACK_PACKAGE_CHECKSUM");
+  if (algoSignature) {
+    if (cmCryptoHash::New(algoSignature).get() == CM_NULLPTR) {
+      cmCPackLogger(cmCPackLog::LOG_ERROR, "Cannot recognize algorithm: "
+                      << algoSignature << std::endl);
+      return 0;
+    }
   }
 
   this->SetOptionIfNotSet("CPACK_REMOVE_TOPLEVEL_DIRECTORY", "1");

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1060,6 +1060,40 @@ ${CMake_BINARY_DIR}/bin/cmake -DDIR=dev -P ${CMake_SOURCE_DIR}/Utilities/Release
 
   endif()
 
+  # CPack checksum tests
+  if(NOT DEFINED CTEST_CPACK_CHECKSUM)
+    set(CTEST_CPACK_CHECKSUM ON)
+  endif()
+
+  if(CTEST_CPACK_CHECKSUM)
+    unset(ChecksumConf)
+    set(CHECK_SUM_TEST "CPackChecksumFile")
+    set(ChecksumConf_TESTS "invalid"
+                           "md5"
+                           "sha1"
+                           "sha224"
+                           "sha256"
+                           "sha384"
+                           "sha512")
+    foreach(ChecksumConf IN LISTS ChecksumConf_TESTS)
+      add_test(CPackChecksumFile-${ChecksumConf} ${CMAKE_CTEST_COMMAND}
+        --build-and-test
+            "${CMake_SOURCE_DIR}/Tests/${CHECK_SUM_TEST}"
+            "${CMake_BINARY_DIR}/Tests/${CHECK_SUM_TEST}/${ChecksumConf}"
+            ${build_generator_args}
+        --build-project CPackChecksumFile
+        --build-options ${build_options}
+            "-DChecksumConf=${ChecksumConf}"
+        --test-command ${CMAKE_CMAKE_COMMAND}
+            "-D${CHECK_SUM_TEST}_BINARY_DIR:PATH=${CMake_BINARY_DIR}/Tests/${CHECK_SUM_TEST}/${ChecksumConf}"
+            "-DCMAKE_CMAKE_COMMAND=${CMAKE_CMAKE_COMMAND}"
+            "-DChecksumConf=${ChecksumConf}"
+            -P "${CMake_SOURCE_DIR}/Tests/${CHECK_SUM_TEST}/VerifyResult.cmake"
+        )
+      list(APPEND TEST_BUILD_DIRS "${CMake_BINARY_DIR}/Tests/${CHECK_SUM_TEST}/${ChecksumConf}")
+    endforeach()
+  endif()
+
   # By default, turn this test off (because it takes a long time...)
   #
   if(NOT DEFINED CTEST_RUN_CPackTestAllGenerators)

--- a/Tests/CPackChecksumFile/CMakeLists.txt
+++ b/Tests/CPackChecksumFile/CMakeLists.txt
@@ -1,0 +1,34 @@
+# CPack test: Verify work of generation checksum files
+#
+# In this test, we create a simple package and generate 
+# different checksum files for it. To verify result we have to assume 
+# what FILE command is working correctly.
+cmake_minimum_required(VERSION 2.6)
+project(CPackChecksumFile)
+
+# Create the mylibapp application
+add_executable(myapp mylibapp.cpp)
+
+# Installing
+install(TARGETS myapp
+  RUNTIME
+  DESTINATION bin
+  COMPONENT apps)
+
+# Packing
+set(CPACK_PACKAGE_NAME "MyApp")
+set(CPACK_PACKAGE_VERSION "1.0.1")
+set(CPACK_GENERATOR "TGZ")
+
+if (NOT DEFINED ChecksumConf)
+  message(FATAL_ERROR "ChecksumConf should be defined")
+endif()
+
+# Setup project specific CPack-time CPack Config file.
+configure_file(${CPackChecksumFile_SOURCE_DIR}/CheckSum-${ChecksumConf}.cmake.in
+               ${CPackChecksumFile_BINARY_DIR}/CheckSum-${ChecksumConf}.cmake
+               @ONLY)
+set(CPACK_PROJECT_CONFIG_FILE ${CPackChecksumFile_BINARY_DIR}/CheckSum-${ChecksumConf}.cmake)
+
+# Include CPack to introduce the appropriate targets
+include(CPack)

--- a/Tests/CPackChecksumFile/CheckSum-invalid.cmake.in
+++ b/Tests/CPackChecksumFile/CheckSum-invalid.cmake.in
@@ -1,0 +1,2 @@
+# Try to generate checksum file using invalid algorithm
+set(CPACK_PACKAGE_CHECKSUM "c6790w4nv2b12n048...")

--- a/Tests/CPackChecksumFile/CheckSum-md5.cmake.in
+++ b/Tests/CPackChecksumFile/CheckSum-md5.cmake.in
@@ -1,0 +1,2 @@
+# Generate MD5 checksum file
+set(CPACK_PACKAGE_CHECKSUM "MD5")

--- a/Tests/CPackChecksumFile/CheckSum-sha1.cmake.in
+++ b/Tests/CPackChecksumFile/CheckSum-sha1.cmake.in
@@ -1,0 +1,2 @@
+# Generate SHA1 checksum file
+set(CPACK_PACKAGE_CHECKSUM "SHA1")

--- a/Tests/CPackChecksumFile/CheckSum-sha224.cmake.in
+++ b/Tests/CPackChecksumFile/CheckSum-sha224.cmake.in
@@ -1,0 +1,2 @@
+# Generate SHA224 checksum file
+set(CPACK_PACKAGE_CHECKSUM "SHA224")

--- a/Tests/CPackChecksumFile/CheckSum-sha256.cmake.in
+++ b/Tests/CPackChecksumFile/CheckSum-sha256.cmake.in
@@ -1,0 +1,2 @@
+# Generate SHA256 checksum file
+set(CPACK_PACKAGE_CHECKSUM "SHA256")

--- a/Tests/CPackChecksumFile/CheckSum-sha384.cmake.in
+++ b/Tests/CPackChecksumFile/CheckSum-sha384.cmake.in
@@ -1,0 +1,2 @@
+# Generate SHA384 checksum file
+set(CPACK_PACKAGE_CHECKSUM "SHA384")

--- a/Tests/CPackChecksumFile/CheckSum-sha512.cmake.in
+++ b/Tests/CPackChecksumFile/CheckSum-sha512.cmake.in
@@ -1,0 +1,2 @@
+# Generate SHA512 checksum file
+set(CPACK_PACKAGE_CHECKSUM "SHA512")

--- a/Tests/CPackChecksumFile/VerifyResult.cmake
+++ b/Tests/CPackChecksumFile/VerifyResult.cmake
@@ -1,0 +1,40 @@
+# prevent older policies from interfearing with this script
+message(STATUS "=============================================================================")
+message(STATUS "CTEST_FULL_OUTPUT (Avoid ctest truncation of output)")
+message(STATUS "")
+
+
+if (NOT DEFINED ChecksumConf)
+  message(FATAL_ERROR "ChecksumConf should be defined")
+endif()
+
+if (NOT DEFINED CPackChecksumFile_BINARY_DIR)
+  message(FATAL_ERROR "CPackChecksumFile_BINARY_DIR should be defined")
+endif()
+
+if (NOT DEFINED CMAKE_CMAKE_COMMAND)
+  message(FATAL_ERROR "CMAKE_CMAKE_COMMAND should be defined")
+endif()
+
+execute_process(COMMAND ${CMAKE_CMAKE_COMMAND} --build . --target package
+                ERROR_VARIABLE CHECKSUM_ERR
+                WORKING_DIRECTORY ${CPackChecksumFile_BINARY_DIR})
+
+# Special case of verify test
+if(ChecksumConf MATCHES "invalid")
+  if(NOT CHECKSUM_ERR MATCHES "CPack Error: Cannot recognize algorithm: c6790w4nv2b12n048...")
+    message(FATAL_ERROR "Error output is not that expected!")
+  endif()
+else()
+# Transform to 
+  string(TOUPPER ${ChecksumConf} ALGO)
+  file(GLOB PACKAGE RELATIVE ${CPackChecksumFile_BINARY_DIR} "*.tar.gz")
+  file(GLOB CSUMFILE RELATIVE ${CPackChecksumFile_BINARY_DIR} "*.${ChecksumConf}")
+  file(STRINGS ${CSUMFILE} CHSUM_VALUE)
+  file(${ALGO} ${PACKAGE} expected_value )
+  set(expected_value "${expected_value}  ${PACKAGE}")
+
+  if(NOT expected_value STREQUAL CHSUM_VALUE)
+    message(FATAL_ERROR "Generated checksum is not valid! Expected [${expected_value}] Got [${CHSUM_VALUE}]")
+  endif()
+endif()

--- a/Tests/CPackChecksumFile/mylibapp.cpp
+++ b/Tests/CPackChecksumFile/mylibapp.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}


### PR DESCRIPTION
Often on creating deployment package you also need to write checksum file for it. This PR allows to generate checksum file as soon as package creates without using external tools and stick only with cpack. 

Usage is pretty simple: set **CPACK_PACKAGE_CHECKSUM** by needed algorithm and file will be generated near to package. In case of multiply packages every package will get it own checksum file. 