### PR TITLE
FindSDL: Add -mwindows to link flags for MinGW, correct wording

### DIFF
--- a/Modules/FindSDL.cmake
+++ b/Modules/FindSDL.cmake
@@ -122,11 +122,10 @@ if(NOT APPLE)
   find_package(Threads)
 endif()
 
-# MinGW needs an additional library, mwindows
-# It's total link flags should look like -lmingw32 -lSDLmain -lSDL -lmwindows
-# (Actually on second look, I think it only needs one of the m* libraries.)
+# MinGW needs an additional link flag, -mwindows
+# It's total link flags should look like -lmingw32 -lSDLmain -lSDL -mwindows
 if(MINGW)
-  set(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+  set(MINGW32_LIBRARY mingw32 "-mwindows" CACHE STRING "link flags for MinGW")
 endif()
 
 if(SDL_LIBRARY_TEMP)


### PR DESCRIPTION
mwindows is not a library. Quoting from https://cygwin.com/ml/cygwin/2007-04/msg00027.html:

> > What does -mwindows mean?

> It just means to set a flag in the PE header that tells the OS not to
> allocate a console for the program when started.  This is usually the
> desired behavior when the program has a GUI, because you don't want the
> console window appearing in that case.  It is really unfortunate that
> somebody decided to call this "-mwindows", it should really be
> -mno-console, which compliments its reciprocal option -mconsole (which
> is the default.)

`-mwindows` is needed to avoid creating an additional console window when starting SDL applications built with MinGW.

This same change was done for the SDL2 find module here: https://github.com/tcbrindle/sdl2-cmake-scripts/pull/6