### PR TITLE
CheckFunctionExists.c: avoid gcc warnings with -Wstrict-prototypes

### DIFF
--- a/Modules/CheckFunctionExists.c
+++ b/Modules/CheckFunctionExists.c
@@ -4,7 +4,7 @@
 extern "C"
 #endif
   char
-  CHECK_FUNCTION_EXISTS();
+  CHECK_FUNCTION_EXISTS(void);
 #ifdef __CLASSIC_C__
 int main()
 {


### PR DESCRIPTION
Avoid warnings (and therefore build failures etc) if a user happens
to add -Wstrict-prototypes to CFLAGS.

 | $ gcc --version
 | gcc (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4
 |
 | $ gcc -Wstrict-prototypes -Werror -DCHECK_FUNCTION_EXISTS=pthread_create -o foo.o -c Modules/CheckFunctionExists.c
 | Modules/CheckFunctionExists.c:7:3: error: function declaration isn't a prototype [-Werror=strict-prototypes]
 |    CHECK_FUNCTION_EXISTS();
 |    ^
 | cc1: all warnings being treated as errors
 |

Signed-off-by: Andre McCurdy <armccurdy@gmail.com>