### PR TITLE
Help: Improve documentation (execute_process, file(REMOVE))

### DIFF
--- a/Help/command/execute_process.rst
+++ b/Help/command/execute_process.rst
@@ -20,7 +20,7 @@ Execute one or more child processes.
                   [OUTPUT_STRIP_TRAILING_WHITESPACE]
                   [ERROR_STRIP_TRAILING_WHITESPACE])
 
-Runs the given sequence of one or more commands with the standard
+Runs the given sequence of one or more commands in parallel with the standard
 output of each process piped to the standard input of the next.
 A single standard error pipe is used for all processes.
 
@@ -35,6 +35,9 @@ Options:
  are treated as normal arguments.
  (Use the ``INPUT_*``, ``OUTPUT_*``, and ``ERROR_*`` options to
  redirect stdin, stdout, and stderr.)
+
+ If a sequential execution of multiple commands is required, use multiple
+ :command:`execute_process` calls with a single ``COMMAND`` argument.
 
 ``WORKING_DIRECTORY``
  The named directory will be set as the current working directory of

--- a/Help/command/file.rst
+++ b/Help/command/file.rst
@@ -153,7 +153,8 @@ Move a file or directory within a filesystem from ``<oldname>`` to
   file(REMOVE_RECURSE [<files>...])
 
 Remove the given files.  The ``REMOVE_RECURSE`` mode will remove the given
-files and directories, also non-empty directories
+files and directories, also non-empty directories. No error is emitted if a
+given file does not exist.
 
 ------------------------------------------------------------------------------
 


### PR DESCRIPTION
This improves the documentation with two issues I ran into recently.

The behavior of `execute_process` is already explained, but I think it would be a good idea to specifically mention that processes are started in parallel (to make the pipes work) and how to achieve sequential execution. Especially because the behavior is different to `add_custom_target/comamnd`. This was recently also reported (by someone else) in http://public.kitware.com/pipermail/cmake/2016-March/063074.html.