### PR TITLE
added lib64 to find_library search PATH_SUFFIXES

### DIFF
--- a/Modules/FindOpenThreads.cmake
+++ b/Modules/FindOpenThreads.cmake
@@ -86,7 +86,7 @@ find_library(OPENTHREADS_LIBRARY
         /opt/csw
         /opt
         /usr/freeware
-    PATH_SUFFIXES lib
+    PATH_SUFFIXES lib lib64
 )
 
 find_library(OPENTHREADS_LIBRARY_DEBUG
@@ -108,7 +108,7 @@ find_library(OPENTHREADS_LIBRARY_DEBUG
         /opt/csw
         /opt
         /usr/freeware
-    PATH_SUFFIXES lib
+    PATH_SUFFIXES lib lib64
 )
 
 if(OPENTHREADS_LIBRARY_DEBUG)


### PR DESCRIPTION
Hi, i recently had to add this fix to my system installed FindOpenThreads.cmake module. I had a custom installation of OpenSceneGraph (and OpenThreads) in my home directory. it installed to lib64 and the system supplied FindOpenSceneGraph.cmake was using the system supplied FindOpenThreads.cmake module, which didn't check lib64. after i added lib64, everything compiled fine.