### PR TITLE
Xcode schemes

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -637,6 +637,7 @@ if(APPLE)
   set(SRCS ${SRCS}
     cmXCodeObject.cxx
     cmXCode21Object.cxx
+    cmXCodeScheme.cxx
     cmGlobalXCodeGenerator.cxx
     cmGlobalXCodeGenerator.h
     cmLocalXCodeGenerator.cxx

--- a/Source/cmGlobalXCodeGenerator.cxx
+++ b/Source/cmGlobalXCodeGenerator.cxx
@@ -3297,7 +3297,8 @@ void cmGlobalXCodeGenerator::OutputXCodeProject(
   }
   this->WriteXCodePBXProj(fout, root, generators);
 
-  // Since the lowest available Xcode version for testing was 7.0, I'm setting this as a limit then
+  // Since the lowest available Xcode version for testing was 7.0, I'm setting
+  // this as a limit then
   //
   if (this->XcodeVersion >= 70)
     this->OutputXCodeSharedSchemes(xcodeDir, root, generators);
@@ -3310,18 +3311,22 @@ void cmGlobalXCodeGenerator::OutputXCodeProject(
     root->GetBinaryDirectory());
 }
 
-void cmGlobalXCodeGenerator::OutputXCodeSharedSchemes(const std::string& xcProjDir,
-  cmLocalGenerator* root, std::vector<cmLocalGenerator*>& generators)
+void cmGlobalXCodeGenerator::OutputXCodeSharedSchemes(
+  const std::string& xcProjDir, cmLocalGenerator* root,
+  std::vector<cmLocalGenerator*>& generators)
 {
-    for (std::vector<cmXCodeObject*>::const_iterator i = this->XCodeObjects.begin();
-         i != this->XCodeObjects.end(); ++i) {
-      cmXCodeObject* obj = *i;
-      if (obj->GetType() == cmXCodeObject::OBJECT &&
-          (obj->GetIsA() == cmXCodeObject::PBXNativeTarget || obj->GetIsA() == cmXCodeObject::PBXAggregateTarget)) {
-        cmXCodeScheme schm(obj, this->XcodeVersion);
-        schm.WriteXCodeSharedScheme(xcProjDir, root->GetCurrentSourceDirectory());
-      }
+  for (std::vector<cmXCodeObject*>::const_iterator i =
+         this->XCodeObjects.begin();
+       i != this->XCodeObjects.end(); ++i) {
+    cmXCodeObject* obj = *i;
+    if (obj->GetType() == cmXCodeObject::OBJECT &&
+        (obj->GetIsA() == cmXCodeObject::PBXNativeTarget ||
+         obj->GetIsA() == cmXCodeObject::PBXAggregateTarget)) {
+      cmXCodeScheme schm(obj, this->XcodeVersion);
+      schm.WriteXCodeSharedScheme(xcProjDir,
+                                  root->GetCurrentSourceDirectory());
     }
+  }
 }
 
 void cmGlobalXCodeGenerator::WriteXCodePBXProj(std::ostream& fout,

--- a/Source/cmGlobalXCodeGenerator.h
+++ b/Source/cmGlobalXCodeGenerator.h
@@ -163,6 +163,10 @@ private:
                           std::vector<cmLocalGenerator*>& generators);
   void OutputXCodeProject(cmLocalGenerator* root,
                           std::vector<cmLocalGenerator*>& generators);
+  // Write shared scheme files for all the native targets
+  void OutputXCodeSharedSchemes(const std::string& xcProjDir,
+                                cmLocalGenerator* root,
+                                std::vector<cmLocalGenerator*>& generators);
   void WriteXCodePBXProj(std::ostream& fout, cmLocalGenerator* root,
                          std::vector<cmLocalGenerator*>& generators);
   cmXCodeObject* CreateXCodeFileReferenceFromPath(const std::string& fullpath,

--- a/Source/cmXCodeScheme.cxx
+++ b/Source/cmXCodeScheme.cxx
@@ -1,175 +1,187 @@
 /* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
    file Copyright.txt or https://cmake.org/licensing for details.  */
 #include "cmXCodeScheme.h"
-#include "cmXMLSafe.h"
 #include "cmGeneratedFileStream.h"
 #include "cmGeneratorTarget.h"
+#include "cmXMLSafe.h"
 
-cmXCodeScheme::cmXCodeScheme(cmXCodeObject* xcObj, unsigned int xcVersion) :
-    targetName(xcObj->GetTarget()->GetName()),
-    targetId(xcObj->GetId()),
-    XcodeVersion(xcVersion)
+cmXCodeScheme::cmXCodeScheme(cmXCodeObject* xcObj, unsigned int xcVersion)
+  : targetName(xcObj->GetTarget()->GetName())
+  , targetId(xcObj->GetId())
+  , XcodeVersion(xcVersion)
 {
 }
 
-void cmXCodeScheme::WriteXCodeSharedScheme(const std::string& xcProjDir, const std::string sourceRoot)
+void cmXCodeScheme::WriteXCodeSharedScheme(const std::string& xcProjDir,
+                                           const std::string sourceRoot)
 {
-    // Create shared scheme sub-directory tree
-    //
-    std::string xcodeSchemeDir = xcProjDir;
-    xcodeSchemeDir += "/xcshareddata/xcschemes";
-    cmSystemTools::MakeDirectory(xcodeSchemeDir.c_str());
+  // Create shared scheme sub-directory tree
+  //
+  std::string xcodeSchemeDir = xcProjDir;
+  xcodeSchemeDir += "/xcshareddata/xcschemes";
+  cmSystemTools::MakeDirectory(xcodeSchemeDir.c_str());
 
-    std::string xcodeSchemeFile = xcodeSchemeDir;
-    xcodeSchemeFile += "/";
-    xcodeSchemeFile += targetName;
-    xcodeSchemeFile += ".xcscheme";
+  std::string xcodeSchemeFile = xcodeSchemeDir;
+  xcodeSchemeFile += "/";
+  xcodeSchemeFile += targetName;
+  xcodeSchemeFile += ".xcscheme";
 
-    cmGeneratedFileStream fout(xcodeSchemeFile.c_str());
-    fout.SetCopyIfDifferent(true);
-    if (!fout) {
-      return;
-    }
+  cmGeneratedFileStream fout(xcodeSchemeFile.c_str());
+  fout.SetCopyIfDifferent(true);
+  if (!fout) {
+    return;
+  }
 
-    std::string xcProjRelDir = xcProjDir.substr(sourceRoot.size() + 1);
-    WriteXCodeXCScheme(fout, xcProjRelDir);
+  std::string xcProjRelDir = xcProjDir.substr(sourceRoot.size() + 1);
+  WriteXCodeXCScheme(fout, xcProjRelDir);
 }
 
-void cmXCodeScheme::WriteXCodeXCScheme(std::ostream& fout, const std::string& xcProjDir)
+void cmXCodeScheme::WriteXCodeXCScheme(std::ostream& fout,
+                                       const std::string& xcProjDir)
 {
-    cmXMLWriter xout(fout);
-    xout.StartDocument();
+  cmXMLWriter xout(fout);
+  xout.StartDocument();
 
-    xout.StartElement("Scheme");
-    xout.BreakAttributes();
-    xout.Attribute("LastUpgradeVersion", WriteVersionString());
-    xout.Attribute("version", "1.3");
+  xout.StartElement("Scheme");
+  xout.BreakAttributes();
+  xout.Attribute("LastUpgradeVersion", WriteVersionString());
+  xout.Attribute("version", "1.3");
 
-    WriteBuildAction(xout, xcProjDir);
-    WriteTestAction(xout, "Debug");
-    WriteLaunchAction(xout, "Release", xcProjDir);
-    WriteProfileAction(xout, "Release");
-    WriteAnalyzeAction(xout, "Debug");
-    WriteArchiveAction(xout, "Release");
+  WriteBuildAction(xout, xcProjDir);
+  WriteTestAction(xout, "Debug");
+  WriteLaunchAction(xout, "Release", xcProjDir);
+  WriteProfileAction(xout, "Release");
+  WriteAnalyzeAction(xout, "Debug");
+  WriteArchiveAction(xout, "Release");
 
-    xout.EndElement();
+  xout.EndElement();
 }
 
-void cmXCodeScheme::WriteBuildAction(cmXMLWriter& xout, const std::string& xcProjDir)
+void cmXCodeScheme::WriteBuildAction(cmXMLWriter& xout,
+                                     const std::string& xcProjDir)
 {
-    xout.StartElement("BuildAction");
-    xout.BreakAttributes();
-    xout.Attribute("parallelizeBuildables", "YES");
-    xout.Attribute("buildImplicitDependencies", "YES");
+  xout.StartElement("BuildAction");
+  xout.BreakAttributes();
+  xout.Attribute("parallelizeBuildables", "YES");
+  xout.Attribute("buildImplicitDependencies", "YES");
 
-    xout.StartElement("BuildActionEntries");
-    xout.StartElement("BuildActionEntry");
-    xout.BreakAttributes();
-    xout.Attribute("buildForTesting", "YES");
-    xout.Attribute("buildForRunning", "YES");
-    xout.Attribute("buildForProfiling", "YES");
-    xout.Attribute("buildForArchiving", "YES");
-    xout.Attribute("buildForAnalyzing", "YES");
+  xout.StartElement("BuildActionEntries");
+  xout.StartElement("BuildActionEntry");
+  xout.BreakAttributes();
+  xout.Attribute("buildForTesting", "YES");
+  xout.Attribute("buildForRunning", "YES");
+  xout.Attribute("buildForProfiling", "YES");
+  xout.Attribute("buildForArchiving", "YES");
+  xout.Attribute("buildForAnalyzing", "YES");
 
-    xout.StartElement("BuildableReference");
-    xout.BreakAttributes();
-    xout.Attribute("BuildableIdentifier", "primary");
-    xout.Attribute("BlueprintIdentifier", targetId);
-    xout.Attribute("BuildableName", targetName);
-    xout.Attribute("BlueprintName", targetName);
-    xout.Attribute("ReferencedContainer", "container:" + xcProjDir);
-    xout.EndElement();
+  xout.StartElement("BuildableReference");
+  xout.BreakAttributes();
+  xout.Attribute("BuildableIdentifier", "primary");
+  xout.Attribute("BlueprintIdentifier", targetId);
+  xout.Attribute("BuildableName", targetName);
+  xout.Attribute("BlueprintName", targetName);
+  xout.Attribute("ReferencedContainer", "container:" + xcProjDir);
+  xout.EndElement();
 
-    xout.EndElement(); // BuildActionEntry
-    xout.EndElement(); // BuildActionEntries
-    xout.EndElement(); // BuildAction
+  xout.EndElement(); // BuildActionEntry
+  xout.EndElement(); // BuildActionEntries
+  xout.EndElement(); // BuildAction
 }
 
-void cmXCodeScheme::WriteTestAction(cmXMLWriter& xout, std::string configuration)
+void cmXCodeScheme::WriteTestAction(cmXMLWriter& xout,
+                                    std::string configuration)
 {
-    xout.StartElement("TestAction");
-    xout.BreakAttributes();
-    xout.Attribute("buildConfiguration", configuration);
-    xout.Attribute("selectedDebuggerIdentifier", "Xcode.DebuggerFoundation.Debugger.LLDB");
-    xout.Attribute("selectedLauncherIdentifier", "Xcode.DebuggerFoundation.Launcher.LLDB");
-    xout.Attribute("shouldUseLaunchSchemeArgsEnv", "YES");
+  xout.StartElement("TestAction");
+  xout.BreakAttributes();
+  xout.Attribute("buildConfiguration", configuration);
+  xout.Attribute("selectedDebuggerIdentifier",
+                 "Xcode.DebuggerFoundation.Debugger.LLDB");
+  xout.Attribute("selectedLauncherIdentifier",
+                 "Xcode.DebuggerFoundation.Launcher.LLDB");
+  xout.Attribute("shouldUseLaunchSchemeArgsEnv", "YES");
 
-    xout.StartElement("Testables");
-    xout.EndElement();
+  xout.StartElement("Testables");
+  xout.EndElement();
 
-    xout.StartElement("AdditionalOptions");
-    xout.EndElement();
+  xout.StartElement("AdditionalOptions");
+  xout.EndElement();
 
-    xout.EndElement(); // TestAction
+  xout.EndElement(); // TestAction
 }
 
-void cmXCodeScheme::WriteLaunchAction(cmXMLWriter& xout, std::string configuration,
+void cmXCodeScheme::WriteLaunchAction(cmXMLWriter& xout,
+                                      std::string configuration,
                                       const std::string& xcProjDir)
 {
-    xout.StartElement("LaunchAction");
-    xout.BreakAttributes();
-    xout.Attribute("buildConfiguration", configuration);
-    xout.Attribute("selectedDebuggerIdentifier", "Xcode.DebuggerFoundation.Debugger.LLDB");
-    xout.Attribute("selectedLauncherIdentifier", "Xcode.DebuggerFoundation.Launcher.LLDB");
-    xout.Attribute("launchStyle", "0");
-    xout.Attribute("useCustomWorkingDirectory", "NO");
-    xout.Attribute("ignoresPersistentStateOnLaunch", "NO");
-    xout.Attribute("debugDocumentVersioning", "YES");
-    xout.Attribute("debugServiceExtension", "internal");
-    xout.Attribute("allowLocationSimulation", "YES");
+  xout.StartElement("LaunchAction");
+  xout.BreakAttributes();
+  xout.Attribute("buildConfiguration", configuration);
+  xout.Attribute("selectedDebuggerIdentifier",
+                 "Xcode.DebuggerFoundation.Debugger.LLDB");
+  xout.Attribute("selectedLauncherIdentifier",
+                 "Xcode.DebuggerFoundation.Launcher.LLDB");
+  xout.Attribute("launchStyle", "0");
+  xout.Attribute("useCustomWorkingDirectory", "NO");
+  xout.Attribute("ignoresPersistentStateOnLaunch", "NO");
+  xout.Attribute("debugDocumentVersioning", "YES");
+  xout.Attribute("debugServiceExtension", "internal");
+  xout.Attribute("allowLocationSimulation", "YES");
 
-    xout.StartElement("MacroExpansion");
+  xout.StartElement("MacroExpansion");
 
-    xout.StartElement("BuildableReference");
-    xout.BreakAttributes();
-    xout.Attribute("BuildableIdentifier", "primary");
-    xout.Attribute("BlueprintIdentifier", targetId);
-    xout.Attribute("BuildableName", targetName);
-    xout.Attribute("BlueprintName", targetName);
-    xout.Attribute("ReferencedContainer", "container:" + xcProjDir);
-    xout.EndElement();
+  xout.StartElement("BuildableReference");
+  xout.BreakAttributes();
+  xout.Attribute("BuildableIdentifier", "primary");
+  xout.Attribute("BlueprintIdentifier", targetId);
+  xout.Attribute("BuildableName", targetName);
+  xout.Attribute("BlueprintName", targetName);
+  xout.Attribute("ReferencedContainer", "container:" + xcProjDir);
+  xout.EndElement();
 
-    xout.EndElement(); // MacroExpansion
+  xout.EndElement(); // MacroExpansion
 
-    xout.StartElement("AdditionalOptions");
-    xout.EndElement();
+  xout.StartElement("AdditionalOptions");
+  xout.EndElement();
 
-    xout.EndElement(); // LaunchAction
+  xout.EndElement(); // LaunchAction
 }
 
-void cmXCodeScheme::WriteProfileAction(cmXMLWriter& xout, std::string configuration)
+void cmXCodeScheme::WriteProfileAction(cmXMLWriter& xout,
+                                       std::string configuration)
 {
-    xout.StartElement("ProfileAction");
-    xout.BreakAttributes();
-    xout.Attribute("buildConfiguration", configuration);
-    xout.Attribute("shouldUseLaunchSchemeArgsEnv", "YES");
-    xout.Attribute("savedToolIdentifier", "");
-    xout.Attribute("useCustomWorkingDirectory", "NO");
-    xout.Attribute("debugDocumentVersioning", "YES");
-    xout.EndElement();
+  xout.StartElement("ProfileAction");
+  xout.BreakAttributes();
+  xout.Attribute("buildConfiguration", configuration);
+  xout.Attribute("shouldUseLaunchSchemeArgsEnv", "YES");
+  xout.Attribute("savedToolIdentifier", "");
+  xout.Attribute("useCustomWorkingDirectory", "NO");
+  xout.Attribute("debugDocumentVersioning", "YES");
+  xout.EndElement();
 }
 
-void cmXCodeScheme::WriteAnalyzeAction(cmXMLWriter& xout, std::string configuration)
+void cmXCodeScheme::WriteAnalyzeAction(cmXMLWriter& xout,
+                                       std::string configuration)
 {
-    xout.StartElement("AnalyzeAction");
-    xout.BreakAttributes();
-    xout.Attribute("buildConfiguration", configuration);
-    xout.EndElement();
+  xout.StartElement("AnalyzeAction");
+  xout.BreakAttributes();
+  xout.Attribute("buildConfiguration", configuration);
+  xout.EndElement();
 }
 
-void cmXCodeScheme::WriteArchiveAction(cmXMLWriter& xout, std::string configuration)
+void cmXCodeScheme::WriteArchiveAction(cmXMLWriter& xout,
+                                       std::string configuration)
 {
-    xout.StartElement("ArchiveAction");
-    xout.BreakAttributes();
-    xout.Attribute("buildConfiguration", configuration);
-    xout.Attribute("revealArchiveInOrganizer", "YES");
-    xout.EndElement();
+  xout.StartElement("ArchiveAction");
+  xout.BreakAttributes();
+  xout.Attribute("buildConfiguration", configuration);
+  xout.Attribute("revealArchiveInOrganizer", "YES");
+  xout.EndElement();
 }
 
 std::string cmXCodeScheme::WriteVersionString()
 {
-    std::string ver = "0";
-    ver += std::to_string(this->XcodeVersion);
-    ver += "0";
-    return ver;
+  std::string ver = "0";
+  ver += std::to_string(this->XcodeVersion);
+  ver += "0";
+  return ver;
 }

--- a/Source/cmXCodeScheme.cxx
+++ b/Source/cmXCodeScheme.cxx
@@ -1,0 +1,175 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+   file Copyright.txt or https://cmake.org/licensing for details.  */
+#include "cmXCodeScheme.h"
+#include "cmXMLSafe.h"
+#include "cmGeneratedFileStream.h"
+#include "cmGeneratorTarget.h"
+
+cmXCodeScheme::cmXCodeScheme(cmXCodeObject* xcObj, unsigned int xcVersion) :
+    targetName(xcObj->GetTarget()->GetName()),
+    targetId(xcObj->GetId()),
+    XcodeVersion(xcVersion)
+{
+}
+
+void cmXCodeScheme::WriteXCodeSharedScheme(const std::string& xcProjDir, const std::string sourceRoot)
+{
+    // Create shared scheme sub-directory tree
+    //
+    std::string xcodeSchemeDir = xcProjDir;
+    xcodeSchemeDir += "/xcshareddata/xcschemes";
+    cmSystemTools::MakeDirectory(xcodeSchemeDir.c_str());
+
+    std::string xcodeSchemeFile = xcodeSchemeDir;
+    xcodeSchemeFile += "/";
+    xcodeSchemeFile += targetName;
+    xcodeSchemeFile += ".xcscheme";
+
+    cmGeneratedFileStream fout(xcodeSchemeFile.c_str());
+    fout.SetCopyIfDifferent(true);
+    if (!fout) {
+      return;
+    }
+
+    std::string xcProjRelDir = xcProjDir.substr(sourceRoot.size() + 1);
+    WriteXCodeXCScheme(fout, xcProjRelDir);
+}
+
+void cmXCodeScheme::WriteXCodeXCScheme(std::ostream& fout, const std::string& xcProjDir)
+{
+    cmXMLWriter xout(fout);
+    xout.StartDocument();
+
+    xout.StartElement("Scheme");
+    xout.BreakAttributes();
+    xout.Attribute("LastUpgradeVersion", WriteVersionString());
+    xout.Attribute("version", "1.3");
+
+    WriteBuildAction(xout, xcProjDir);
+    WriteTestAction(xout, "Debug");
+    WriteLaunchAction(xout, "Release", xcProjDir);
+    WriteProfileAction(xout, "Release");
+    WriteAnalyzeAction(xout, "Debug");
+    WriteArchiveAction(xout, "Release");
+
+    xout.EndElement();
+}
+
+void cmXCodeScheme::WriteBuildAction(cmXMLWriter& xout, const std::string& xcProjDir)
+{
+    xout.StartElement("BuildAction");
+    xout.BreakAttributes();
+    xout.Attribute("parallelizeBuildables", "YES");
+    xout.Attribute("buildImplicitDependencies", "YES");
+
+    xout.StartElement("BuildActionEntries");
+    xout.StartElement("BuildActionEntry");
+    xout.BreakAttributes();
+    xout.Attribute("buildForTesting", "YES");
+    xout.Attribute("buildForRunning", "YES");
+    xout.Attribute("buildForProfiling", "YES");
+    xout.Attribute("buildForArchiving", "YES");
+    xout.Attribute("buildForAnalyzing", "YES");
+
+    xout.StartElement("BuildableReference");
+    xout.BreakAttributes();
+    xout.Attribute("BuildableIdentifier", "primary");
+    xout.Attribute("BlueprintIdentifier", targetId);
+    xout.Attribute("BuildableName", targetName);
+    xout.Attribute("BlueprintName", targetName);
+    xout.Attribute("ReferencedContainer", "container:" + xcProjDir);
+    xout.EndElement();
+
+    xout.EndElement(); // BuildActionEntry
+    xout.EndElement(); // BuildActionEntries
+    xout.EndElement(); // BuildAction
+}
+
+void cmXCodeScheme::WriteTestAction(cmXMLWriter& xout, std::string configuration)
+{
+    xout.StartElement("TestAction");
+    xout.BreakAttributes();
+    xout.Attribute("buildConfiguration", configuration);
+    xout.Attribute("selectedDebuggerIdentifier", "Xcode.DebuggerFoundation.Debugger.LLDB");
+    xout.Attribute("selectedLauncherIdentifier", "Xcode.DebuggerFoundation.Launcher.LLDB");
+    xout.Attribute("shouldUseLaunchSchemeArgsEnv", "YES");
+
+    xout.StartElement("Testables");
+    xout.EndElement();
+
+    xout.StartElement("AdditionalOptions");
+    xout.EndElement();
+
+    xout.EndElement(); // TestAction
+}
+
+void cmXCodeScheme::WriteLaunchAction(cmXMLWriter& xout, std::string configuration,
+                                      const std::string& xcProjDir)
+{
+    xout.StartElement("LaunchAction");
+    xout.BreakAttributes();
+    xout.Attribute("buildConfiguration", configuration);
+    xout.Attribute("selectedDebuggerIdentifier", "Xcode.DebuggerFoundation.Debugger.LLDB");
+    xout.Attribute("selectedLauncherIdentifier", "Xcode.DebuggerFoundation.Launcher.LLDB");
+    xout.Attribute("launchStyle", "0");
+    xout.Attribute("useCustomWorkingDirectory", "NO");
+    xout.Attribute("ignoresPersistentStateOnLaunch", "NO");
+    xout.Attribute("debugDocumentVersioning", "YES");
+    xout.Attribute("debugServiceExtension", "internal");
+    xout.Attribute("allowLocationSimulation", "YES");
+
+    xout.StartElement("MacroExpansion");
+
+    xout.StartElement("BuildableReference");
+    xout.BreakAttributes();
+    xout.Attribute("BuildableIdentifier", "primary");
+    xout.Attribute("BlueprintIdentifier", targetId);
+    xout.Attribute("BuildableName", targetName);
+    xout.Attribute("BlueprintName", targetName);
+    xout.Attribute("ReferencedContainer", "container:" + xcProjDir);
+    xout.EndElement();
+
+    xout.EndElement(); // MacroExpansion
+
+    xout.StartElement("AdditionalOptions");
+    xout.EndElement();
+
+    xout.EndElement(); // LaunchAction
+}
+
+void cmXCodeScheme::WriteProfileAction(cmXMLWriter& xout, std::string configuration)
+{
+    xout.StartElement("ProfileAction");
+    xout.BreakAttributes();
+    xout.Attribute("buildConfiguration", configuration);
+    xout.Attribute("shouldUseLaunchSchemeArgsEnv", "YES");
+    xout.Attribute("savedToolIdentifier", "");
+    xout.Attribute("useCustomWorkingDirectory", "NO");
+    xout.Attribute("debugDocumentVersioning", "YES");
+    xout.EndElement();
+}
+
+void cmXCodeScheme::WriteAnalyzeAction(cmXMLWriter& xout, std::string configuration)
+{
+    xout.StartElement("AnalyzeAction");
+    xout.BreakAttributes();
+    xout.Attribute("buildConfiguration", configuration);
+    xout.EndElement();
+}
+
+void cmXCodeScheme::WriteArchiveAction(cmXMLWriter& xout, std::string configuration)
+{
+    xout.StartElement("ArchiveAction");
+    xout.BreakAttributes();
+    xout.Attribute("buildConfiguration", configuration);
+    xout.Attribute("revealArchiveInOrganizer", "YES");
+    xout.EndElement();
+}
+
+std::string cmXCodeScheme::WriteVersionString()
+{
+    std::string ver = "0";
+    ver += std::to_string(this->XcodeVersion);
+    ver += "0";
+    return ver;
+}

--- a/Source/cmXCodeScheme.h
+++ b/Source/cmXCodeScheme.h
@@ -1,0 +1,40 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+   file Copyright.txt or https://cmake.org/licensing for details.  */
+#ifndef cmXCodeScheme_h
+#define cmXCodeScheme_h
+
+#include <cmConfigure.h> // IWYU pragma: keep
+
+#include "cmXCodeObject.h"
+#include "cmGlobalXCodeGenerator.h"
+#include "cmXMLWriter.h"
+#include "cmSystemTools.h"
+
+/** \class cmXCodeScheme
+ * \brief Write shared schemes for native targets in Xcode project.
+ */
+class cmXCodeScheme
+{
+public:
+    cmXCodeScheme(cmXCodeObject* xcObj, unsigned int xcVersion);
+
+    void WriteXCodeSharedScheme(const std::string& xcProjDir, const std::string sourceRoot);
+private:
+    const std::string& targetName;
+    const std::string& targetId;
+    unsigned int XcodeVersion;
+
+    void WriteXCodeXCScheme(std::ostream& fout, const std::string& xcProjDir);
+
+    void WriteBuildAction(cmXMLWriter& xout, const std::string& xcProjDir);
+    void WriteTestAction(cmXMLWriter& xout, std::string configuration);
+    void WriteLaunchAction(cmXMLWriter& xout, std::string configuration,
+                           const std::string& xcProjDir);
+    void WriteProfileAction(cmXMLWriter& xout, std::string configuration);
+    void WriteAnalyzeAction(cmXMLWriter& xout, std::string configuration);
+    void WriteArchiveAction(cmXMLWriter& xout, std::string configuration);
+
+    std::string WriteVersionString();
+};
+
+#endif

--- a/Source/cmXCodeScheme.h
+++ b/Source/cmXCodeScheme.h
@@ -5,10 +5,10 @@
 
 #include <cmConfigure.h> // IWYU pragma: keep
 
-#include "cmXCodeObject.h"
 #include "cmGlobalXCodeGenerator.h"
-#include "cmXMLWriter.h"
 #include "cmSystemTools.h"
+#include "cmXCodeObject.h"
+#include "cmXMLWriter.h"
 
 /** \class cmXCodeScheme
  * \brief Write shared schemes for native targets in Xcode project.
@@ -16,25 +16,27 @@
 class cmXCodeScheme
 {
 public:
-    cmXCodeScheme(cmXCodeObject* xcObj, unsigned int xcVersion);
+  cmXCodeScheme(cmXCodeObject* xcObj, unsigned int xcVersion);
 
-    void WriteXCodeSharedScheme(const std::string& xcProjDir, const std::string sourceRoot);
+  void WriteXCodeSharedScheme(const std::string& xcProjDir,
+                              const std::string sourceRoot);
+
 private:
-    const std::string& targetName;
-    const std::string& targetId;
-    unsigned int XcodeVersion;
+  const std::string& targetName;
+  const std::string& targetId;
+  unsigned int XcodeVersion;
 
-    void WriteXCodeXCScheme(std::ostream& fout, const std::string& xcProjDir);
+  void WriteXCodeXCScheme(std::ostream& fout, const std::string& xcProjDir);
 
-    void WriteBuildAction(cmXMLWriter& xout, const std::string& xcProjDir);
-    void WriteTestAction(cmXMLWriter& xout, std::string configuration);
-    void WriteLaunchAction(cmXMLWriter& xout, std::string configuration,
-                           const std::string& xcProjDir);
-    void WriteProfileAction(cmXMLWriter& xout, std::string configuration);
-    void WriteAnalyzeAction(cmXMLWriter& xout, std::string configuration);
-    void WriteArchiveAction(cmXMLWriter& xout, std::string configuration);
+  void WriteBuildAction(cmXMLWriter& xout, const std::string& xcProjDir);
+  void WriteTestAction(cmXMLWriter& xout, std::string configuration);
+  void WriteLaunchAction(cmXMLWriter& xout, std::string configuration,
+                         const std::string& xcProjDir);
+  void WriteProfileAction(cmXMLWriter& xout, std::string configuration);
+  void WriteAnalyzeAction(cmXMLWriter& xout, std::string configuration);
+  void WriteArchiveAction(cmXMLWriter& xout, std::string configuration);
 
-    std::string WriteVersionString();
+  std::string WriteVersionString();
 };
 
 #endif


### PR DESCRIPTION
I've implemented an Xcode shared scheme writer which mimics the way Xcode generates schemes for all the targets in a project generated by CMake. I've tested it on Xcode 7.0.1, 7.3.1, 8.0, 8.1 and 8.2.1.

This is necessary for automated building and testing using xcodebuild command line instead of Xcode GUI application. The xcodebuild itself does not generate neither private nor shared schemes and thus analyze, archive, build-for-testing and test actions are impossible to run.

I chose to generate shared schemes as they don't require knowing the user's login name. And I chose to create an extra class for schemes because it could be later re-used if for example someone implements Xcode workspace generation (which also can host schemes).

I think that current solution could be advanced further with additional CMake options, but for now it would be enough to just generate a project and be able to build it using command line tools that in some cases require schemes.

If I've forgotten something, please, let me know. :)