### PR TITLE
Force generation of folders for Express editions of VS10 and earlier

### DIFF
--- a/Source/cmGlobalVisualStudio8Generator.cxx
+++ b/Source/cmGlobalVisualStudio8Generator.cxx
@@ -10,6 +10,7 @@
 #include "cmSourceFile.h"
 #include "cmVisualStudioWCEPlatformParser.h"
 #include "cmake.h"
+#include "cmState.h"
 
 static const char vs8generatorName[] = "Visual Studio 8 2005";
 
@@ -172,7 +173,11 @@ void cmGlobalVisualStudio8Generator::Configure()
 
 bool cmGlobalVisualStudio8Generator::UseFolderProperty()
 {
-  return IsExpressEdition() ? false : cmGlobalGenerator::UseFolderProperty();
+  const char* prop = this->GetCMakeInstance()->GetState()->
+                       GetGlobalProperty("FORCE_USE_FOLDERS");
+  const bool forceUseFolders = prop ? cmSystemTools::IsOn(prop) : false;
+  return (IsExpressEdition() && !forceUseFolders) ?
+    false : cmGlobalGenerator::UseFolderProperty();
 }
 
 std::string cmGlobalVisualStudio8Generator::GetUserMacrosDirectory()


### PR DESCRIPTION
When for compatibility reasons VS10 compilers need to be used, one can still use a newer VS version (supporting folders) as IDE. This patch allows to force the generation of folders even when an Express edition of VS10 is detected by setting the property FORCE_USE_FOLDERS to true.

See also https://cmake.org/pipermail/cmake/2017-January/064942.html