### PR TITLE
allow override (OPENCL_ROOT) for where comes from

### DIFF
--- a/Modules/FindOpenCL.cmake
+++ b/Modules/FindOpenCL.cmake
@@ -70,6 +70,7 @@ find_path(OpenCL_INCLUDE_DIR
   NAMES
     CL/cl.h OpenCL/cl.h
   PATHS
+    ENV OPENCL_ROOT
     ENV "PROGRAMFILES(X86)"
     ENV AMDAPPSDKROOT
     ENV INTELOCLSDKROOT
@@ -88,6 +89,7 @@ if(WIN32)
     find_library(OpenCL_LIBRARY
       NAMES OpenCL
       PATHS
+        ENV OPENCL_ROOT
         ENV "PROGRAMFILES(X86)"
         ENV AMDAPPSDKROOT
         ENV INTELOCLSDKROOT
@@ -103,6 +105,7 @@ if(WIN32)
     find_library(OpenCL_LIBRARY
       NAMES OpenCL
       PATHS
+        ENV OPENCL_ROOT
         ENV "PROGRAMFILES(X86)"
         ENV AMDAPPSDKROOT
         ENV INTELOCLSDKROOT


### PR DESCRIPTION
We can't expect this script to cover all the different vendors of
OpenCL.  So let's just make a unified variable for users to specify
where we should look.