### PR TITLE
Add in another name combo for libcrypto that matches libssl.

### DIFF
--- a/Modules/FindOpenSSL.cmake
+++ b/Modules/FindOpenSSL.cmake
@@ -160,6 +160,7 @@ if(WIN32 AND NOT CYGWIN)
         libcrypto
         libeay32${_OPENSSL_MSVC_RT_MODE}
         libeay32
+        crypto
       NAMES_PER_DIR
       ${_OPENSSL_ROOT_HINTS_AND_PATHS}
       PATH_SUFFIXES


### PR DESCRIPTION
libcrypto should have matching find pattern that libssl has for builds without the prefix on the front.