### PR TITLE
Cache the list of xaml and resx headers to speedup VS project generation

### DIFF
--- a/Source/cmGeneratorTarget.cxx
+++ b/Source/cmGeneratorTarget.cxx
@@ -711,12 +711,17 @@ void cmGeneratorTarget::GetExternalObjects(
   IMPLEMENT_VISIT(ExternalObjects);
 }
 
-void cmGeneratorTarget::GetExpectedResxHeaders(std::set<std::string>& srcs,
+void cmGeneratorTarget::GetExpectedResxHeaders(std::set<std::string>& headers,
                                                const std::string& config) const
 {
-  ResxData data;
-  IMPLEMENT_VISIT_IMPL(Resx, COMMA cmGeneratorTarget::ResxData)
-  srcs = data.ExpectedResxHeaders;
+  static std::unique_ptr<std::set<std::string> > cachedExpectedResxHeaders;
+  if (cachedExpectedResxHeaders == nullptr)
+  {
+    ResxData data;
+    IMPLEMENT_VISIT_IMPL(Resx, COMMA cmGeneratorTarget::ResxData)
+    cachedExpectedResxHeaders.reset(new std::set<std::string>(data.ExpectedResxHeaders));
+  }
+  headers = *cachedExpectedResxHeaders.get();
 }
 
 void cmGeneratorTarget::GetResxSources(std::vector<cmSourceFile const*>& srcs,
@@ -748,9 +753,14 @@ void cmGeneratorTarget::GetCertificates(std::vector<cmSourceFile const*>& data,
 void cmGeneratorTarget::GetExpectedXamlHeaders(std::set<std::string>& headers,
                                                const std::string& config) const
 {
-  XamlData data;
-  IMPLEMENT_VISIT_IMPL(Xaml, COMMA cmGeneratorTarget::XamlData)
-  headers = data.ExpectedXamlHeaders;
+  static std::unique_ptr<std::set<std::string> > cachedExpectedXamlHeaders;
+  if (cachedExpectedXamlHeaders == nullptr)
+  {
+    XamlData data;
+    IMPLEMENT_VISIT_IMPL(Xaml, COMMA cmGeneratorTarget::XamlData)
+    cachedExpectedXamlHeaders.reset(new std::set<std::string>(data.ExpectedXamlHeaders));
+  }
+  headers = *cachedExpectedXamlHeaders.get();
 }
 
 void cmGeneratorTarget::GetExpectedXamlSources(std::set<std::string>& srcs,


### PR DESCRIPTION
Hi!

I've realized that for our huge multi-repository project cmake on Windows runs significantly slower than on Linux.
I've run it in standard VS2015 profiler just to check if there are low-hanging fruits.
Surprisingly GetExpectedResxHeaders and GetExpectedXamlHeaders functions were consuming about 38% of whole CPU time. The reason is that they are triggered for each line when you need to put file inside vcxproj (and check whether it is XAML/RESX header) and they populate a list from scratch.
So I decided to put it in local static var to keep content cached.
For our project the improvement with this change is from 4m44s to 4m12s.
Please let me know if I should use some other approach than static vars.

Regards, 
Dmitry