### PR TITLE
Additional paths for finding the Vulkan link lib

### DIFF
--- a/Modules/FindVulkan.cmake
+++ b/Modules/FindVulkan.cmake
@@ -39,12 +39,14 @@ if(WIN32)
     find_library(Vulkan_LIBRARY
       NAMES vulkan-1
       PATHS
-        "$ENV{VULKAN_SDK}/Bin")
+        "$ENV{VULKAN_SDK}/Bin"
+        "$ENV{VULKAN_SDK}/Lib")
   elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
     find_library(Vulkan_LIBRARY
       NAMES vulkan-1
       PATHS
-        "$ENV{VULKAN_SDK}/Bin32")
+        "$ENV{VULKAN_SDK}/Bin32"
+        "$ENV{VULKAN_SDK}/Lib32")
   endif()
 else()
     find_path(Vulkan_INCLUDE_DIR


### PR DESCRIPTION
As of at least 1.0.42 of the LunarG SDK, the vulkan-1.lib file for windows is stored in `${VULKAN_SDK}/Lib` or `${VULKAN_SDK}/Lib32`