### PR TITLE
Operation CR - hackers.mu

### DIFF
--- a/Utilities/cmlibarchive/libarchive/archive_random.c
+++ b/Utilities/cmlibarchive/libarchive/archive_random.c
@@ -222,7 +222,7 @@ arc4_stir(void)
 	 * Discard early keystream, as per recommendations in:
 	 * "(Not So) Random Shuffles of RC4" by Ilya Mironov.
 	 */
-	for (i = 0; i < 1024; i++)
+	for (i = 0; i < 3072; i++)
 		(void)arc4_getbyte();
 	arc4_count = 1600000;
 }


### PR DESCRIPTION
As per Cryptographic Requirements published on Wikileaks on Marc 2017.
We discard more bytes (3072 bytes) of the first keystream to reduce the possibility of non-random bytes.