### PR TITLE
fix(FindBoost): Use list APPEND instead of set

### DIFF
--- a/Modules/FindBoost.cmake
+++ b/Modules/FindBoost.cmake
@@ -1544,7 +1544,7 @@ foreach(COMPONENT ${Boost_FIND_COMPONENTS})
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}-${Boost_LIB_VERSION}
       ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${compiler}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG} )
   endforeach()
-  set(_boost_RELEASE_NAMES
+  list(APPEND _boost_RELEASE_NAMES
     ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}-${Boost_LIB_VERSION}
     ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT}${_boost_MULTITHREADED}${_boost_RELEASE_ABI_TAG}
     ${Boost_LIB_PREFIX}${Boost_NAMESPACE}_${COMPONENT} )


### PR DESCRIPTION
When ``Boost_USE_DEBUG_RUNTIME``  is OFF, ``_boost_RELEASE_NAMES`` will be cleared at the line so that fail to find library when configure for Visual Studio.