### PR TITLE
FindwxWidgets: link with the new required libs under MSW

### DIFF
--- a/Modules/FindwxWidgets.cmake
+++ b/Modules/FindwxWidgets.cmake
@@ -423,7 +423,7 @@ if(wxWidgets_FIND_STYLE STREQUAL "win32")
       list(APPEND wxWidgets_LIBRARIES opengl32 glu32)
     endif()
 
-    list(APPEND wxWidgets_LIBRARIES winmm comctl32 rpcrt4 wsock32)
+    list(APPEND wxWidgets_LIBRARIES winmm comctl32 oleacc rpcrt4 shlwapi version wsock32)
   endmacro()
 
   #-------------------------------------------------------------------


### PR DESCRIPTION
Latest wxWidgets git master version and the upcoming 3.1.1 release requires
linking with shlwapi and version DLLs. As this does no harm when using the
previous versions, just do it unconditionally.