### PR TITLE
Fix missing PATHS keyword in FindOpenCL.cmake

### DIFF
--- a/Modules/FindOpenCL.cmake
+++ b/Modules/FindOpenCL.cmake
@@ -118,6 +118,7 @@ if(WIN32)
 else()
   find_library(OpenCL_LIBRARY
     NAMES OpenCL
+    PATHS
       ENV AMDAPPSDKROOT
     PATH_SUFFIXES
       lib/x86_64


### PR DESCRIPTION
Fixes typo: missing PATHS keyword in find_library(..) call for non-windows platforms.
Without it properly installed AMD APP SDK (OpenCL) cannot be detected.
Tested on Ubuntu 16.04