### PR TITLE
Fix assertion error of std::string, in testValue

### DIFF
--- a/Source/cmServerProtocol.cxx
+++ b/Source/cmServerProtocol.cxx
@@ -289,7 +289,9 @@ static bool testValue(cmState* state, const std::string& key,
                       std::string& value, const std::string& keyDescription,
                       std::string* errorMessage)
 {
-  const std::string cachedValue = std::string(state->GetCacheEntryValue(key));
+  const char* entry = state->GetCacheEntryValue(key);
+  const std::string cachedValue =
+    entry == nullptr ? std::string() : std::string(entry);
   if (!cachedValue.empty() && !value.empty() && cachedValue != value) {
     setErrorMessage(errorMessage, std::string("\"") + key +
                       "\" is set but incompatible with configured " +


### PR DESCRIPTION
`std::string` cannot be constructed from `nullptr`. With libstdc++, that [throws an assertion][1].

  [1]: https://github.com/vector-of-bool/vscode-cmake-tools/issues/210#issue-242629167
