### PR TITLE
cmSystemTools: use GetRealPath in FindCMakeResources on Windows to resolve symbolic links

### DIFF
--- a/Source/cmSystemTools.cxx
+++ b/Source/cmSystemTools.cxx
@@ -2090,8 +2090,12 @@ void cmSystemTools::FindCMakeResources(const char* argv0)
   (void)argv0; // ignore this on windows
   wchar_t modulepath[_MAX_PATH];
   ::GetModuleFileNameW(NULL, modulepath, sizeof(modulepath));
-  exe_dir =
-    cmSystemTools::GetFilenamePath(cmsys::Encoding::ToNarrow(modulepath));
+  std::string path = cmsys::Encoding::ToNarrow(modulepath);
+  std::string realPath = cmSystemTools::GetRealPath(path, NULL);
+  if (realPath.empty()) {
+    realPath = path;
+  }
+  exe_dir = cmSystemTools::GetFilenamePath(path);
 #elif defined(__APPLE__)
   (void)argv0; // ignore this on OS X
 #define CM_EXE_PATH_LOCAL_SIZE 16384


### PR DESCRIPTION
If cmake.exe was executed through a symbolic link then GetModuleFileNameW will return location of that symbolic link instead of real path of cmake.exe. This results in the following error output: "CMake Error: Could not find CMAKE_ROOT !!! CMake has most likely not been installed correctly."

Thanks for your interest in contributing to CMake!  The GitHub repository
is a mirror provided for convenience, but CMake does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/cmake/cmake/tree/master/CONTRIBUTING.rst

for contribution instructions.  GitHub OAuth may be used to sign in.
