### PR TITLE
Fix for bug at FindwxWidgets.cmake:928 file failed to open for reading (No such file or directory)

### DIFF
--- a/Modules/FindwxWidgets.cmake
+++ b/Modules/FindwxWidgets.cmake
@@ -925,6 +925,7 @@ unset(_wx_lib_missing)
 
 # Check if a specific version was requested by find_package().
 if(wxWidgets_FOUND)
+  unset(_filename)
   find_file(_filename wx/version.h PATHS ${wxWidgets_INCLUDE_DIRS} NO_DEFAULT_PATH)
   dbg_msg("_filename:  ${_filename}")
 


### PR DESCRIPTION
--------------------------------------------------------------------------------------
ERROR without debugging enabled
--------------------------------------------------------------------------------------
-- +++ processing catkin package: 'cmvision'
-- ==> add_subdirectory(blob-tracking/cmvision)
-- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
-- cmvision: 2 messages, 0 services
CMake Error at /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake:861 (file):
  file failed to open for reading (No such file or directory):

    /mnt/data/workspace/ros/src/blob-tracking/cmvision/Blob
Call Stack (most recent call first):
  blob-tracking/cmvision/CMakeLists.txt:29 (find_package)


-- Found wxWidgets: -L/usr/lib/arm-linux-gnueabihf;-pthread;;;-lwx_gtk2u_xrc-3.0;-lwx_gtk2u_webview-3.0;-lwx_gtk2u_html-3.0;-lwx_gtk2u_qa-3.0;-lwx_gtk2u_adv-3.0;-lwx_gtk2u_core-3.0;-lwx_baseu_xml-3.0;-lwx_baseu_net-3.0;-lwx_baseu-3.0 (found version "..") 



--------------------------------------------------------------------------------------
ERROR with DBG_MSG and DBG_MSG_V debugging enabled
--------------------------------------------------------------------------------------
-- +++ processing catkin package: 'cmvision'
-- ==> add_subdirectory(blob-tracking/cmvision)
-- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
-- cmvision: 2 messages, 0 services
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(177): wxWidgets_FIND_COMPONENTS : 
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(177): wxWidgets_SELECT_OPTIONS=--debug=no
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(181): wxWidgets_CXX_FLAGS=-I/usr/lib/arm-linux-gnueabihf/wx/include/gtk2-unicode-3.0;-I/usr/include/wx-3.0;-D_FILE_OFFSET_BITS=64;-DWXUSINGDLL;-D__WXGTK__;-pthread
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(181): wxWidgets_DEFINITIONS=_FILE_OFFSET_BITS=64;WXUSINGDLL;__WXGTK__
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(181): wxWidgets_INCLUDE_DIRS=/usr/lib/arm-linux-gnueabihf/wx/include/gtk2-unicode-3.0;/usr/include/wx-3.0
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(181): wxWidgets_CXX_FLAGS=-pthread
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(181): wxWidgets_LIBRARIES=-L/usr/lib/arm-linux-gnueabihf;-pthread;;;-lwx_gtk2u_xrc-3.0;-lwx_gtk2u_webview-3.0;-lwx_gtk2u_html-3.0;-lwx_gtk2u_qa-3.0;-lwx_gtk2u_adv-3.0;-lwx_gtk2u_core-3.0;-lwx_baseu_xml-3.0;-lwx_baseu_net-3.0;-lwx_baseu-3.0
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(181): wxWidgets_LIBRARY_DIRS=/usr/lib/arm-linux-gnueabihf
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(177): _filename:  Blob
CMake Error at /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake:861 (file):
  file failed to open for reading (No such file or directory):

    /mnt/data/workspace/ros/src/blob-tracking/cmvision/Blob
Call Stack (most recent call first):
  blob-tracking/cmvision/CMakeLists.txt:29 (find_package)


-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(177): wxWidgets_VERSION_STRING:    ..
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(177): wxWidgets_FOUND           : TRUE
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(177): wxWidgets_INCLUDE_DIRS    : /usr/lib/arm-linux-gnueabihf/wx/include/gtk2-unicode-3.0;/usr/include/wx-3.0
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(177): wxWidgets_LIBRARY_DIRS    : /usr/lib/arm-linux-gnueabihf
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(177): wxWidgets_LIBRARIES       : -L/usr/lib/arm-linux-gnueabihf;-pthread;;;-lwx_gtk2u_xrc-3.0;-lwx_gtk2u_webview-3.0;-lwx_gtk2u_html-3.0;-lwx_gtk2u_qa-3.0;-lwx_gtk2u_adv-3.0;-lwx_gtk2u_core-3.0;-lwx_baseu_xml-3.0;-lwx_baseu_net-3.0;-lwx_baseu-3.0
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(177): wxWidgets_CXX_FLAGS       : -pthread
-- /usr/share/cmake-3.5/Modules/FindwxWidgets.cmake(177): wxWidgets_USE_FILE        : /usr/share/cmake-3.5/Modules/UsewxWidgets.cmake


Note that source directory for the cmvision ROS package is: src/blob-tracking/cmvision (maybe it's a regexp problem where 'blob-tracking' is truncated and capitalized?)

--------------------------------------------------------------------------------------
Steps to reproduce:
--------------------------------------------------------------------------------------
1) Install ROS Kinetic on Ubuntu 16.04: http://wiki.ros.org/kinetic/Installation/Ubuntu
2) Create a new workspace: http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment#Create_a_ROS_Workspace
3) mkdir & cd into src/blob-tracking and clone cmvision: https://github.com/OSUrobotics/cmvision
4) build with catkin_make
