### PR TITLE
Element StyleSheet has been added to CPack IFW

### DIFF
--- a/Help/cpack_gen/ifw.rst
+++ b/Help/cpack_gen/ifw.rst
@@ -135,6 +135,10 @@ Package
 
  Wizard style to be used ("Modern", "Mac", "Aero" or "Classic").
 
+.. variable:: CPACK_IFW_PACKAGE_STYLESHEET
+
+ Set the stylesheet file.
+
 .. variable:: CPACK_IFW_PACKAGE_WIZARD_DEFAULT_WIDTH
 
  Default width of the wizard in pixels. Setting a banner image will override this.

--- a/Source/CPack/IFW/cmCPackIFWInstaller.cxx
+++ b/Source/CPack/IFW/cmCPackIFWInstaller.cxx
@@ -152,6 +152,15 @@ void cmCPackIFWInstaller::ConfigureFromOptions()
     }
   }
 
+  // StyleSheet
+  if (const char* option = this->GetOption("CPACK_IFW_PACKAGE_STYLESHEET")) {
+    if (cmSystemTools::FileExists(option)) {
+      this->StyleSheet = option;
+    } else {
+      this->printSkippedOptionWarning("CPACK_IFW_PACKAGE_STYLESHEET", option);
+    }
+  }
+
   // WizardDefaultWidth
   if (const char* option =
         this->GetOption("CPACK_IFW_PACKAGE_WIZARD_DEFAULT_WIDTH")) {
@@ -379,6 +388,14 @@ void cmCPackIFWInstaller::GenerateInstallerFile()
   // WizardStyle
   if (!this->WizardStyle.empty()) {
     xout.Element("WizardStyle", this->WizardStyle);
+  }
+
+  // Stylesheet
+  if (!this->StyleSheet.empty()) {
+    std::string name = cmSystemTools::GetFilenameName(this->StyleSheet);
+    std::string path = this->Directory + "/config/" + name;
+    cmsys::SystemTools::CopyFileIfDifferent(this->StyleSheet, path);
+    xout.Element("StyleSheet", name);
   }
 
   // WizardDefaultWidth

--- a/Source/CPack/IFW/cmCPackIFWInstaller.h
+++ b/Source/CPack/IFW/cmCPackIFWInstaller.h
@@ -72,6 +72,9 @@ public:
   /// Wizard style name
   std::string WizardStyle;
 
+  /// Filename for a style sheet
+  std::string StyleSheet;
+
   /// Wizard width
   std::string WizardDefaultWidth;
 


### PR DESCRIPTION
According to [QtIFW documentation](https://doc.qt.io/qtinstallerframework/ifw-globalconfig.html), configuration file is able to include style sheet file path (StyleSheet element). 
But, unfortunately, current implementation of CPack doesn't support the feature.
