### PR TITLE
Set minimum R2018a --> R2017b for C++API 

### DIFF
--- a/Modules/FindMatlab.cmake
+++ b/Modules/FindMatlab.cmake
@@ -107,9 +107,9 @@ Result variables
   Matlab matrix library. Available only if the component ``MAT_LIBRARY``
   is requested.
 ``Matlab_ENGINE_LIBRARY``
-  Matlab C++ engine library, always available for R2018a and newer.
+  Matlab C++ engine library, always available for R2017b and newer.
 ``Matlab_DATAARRAY_LIBRARY``
-  Matlab C++ data array library, always available for R2018a and newer.
+  Matlab C++ data array library, always available for R2017b and newer.
 ``Matlab_LIBRARIES``
   the whole set of libraries of Matlab
 ``Matlab_MEX_COMPILER``
@@ -1725,7 +1725,7 @@ unset(_matlab_find_mcc_compiler)
 
 if(Matlab_HAS_CPP_API)
 
-  # The MatlabEngine library is required for R2018a+
+  # The MatlabEngine library is required for R2017b+
   _Matlab_find_library(
     ${_matlab_lib_prefix_for_search}
     Matlab_ENGINE_LIBRARY
@@ -1739,7 +1739,7 @@ if(Matlab_HAS_CPP_API)
     set(Matlab_ENGINE_LIBRARY_FOUND TRUE)
   endif()
 
-  # The MatlabDataArray library is required for R2018a+
+  # The MatlabDataArray library is required for R2017b+
   _Matlab_find_library(
     ${_matlab_lib_prefix_for_search}
     Matlab_DATAARRAY_LIBRARY

--- a/Modules/FindMatlab.cmake
+++ b/Modules/FindMatlab.cmake
@@ -1503,7 +1503,7 @@ if(MATLAB_FIND_DEBUG)
   message(STATUS "[MATLAB] Current version is ${Matlab_VERSION_STRING} located ${Matlab_ROOT_DIR}")
 endif()
 
-if(NOT ${Matlab_VERSION_STRING} VERSION_LESS "9.4") # MATLAB 9.4 (R2018a) and newer have a new C++ API
+if(NOT ${Matlab_VERSION_STRING} VERSION_LESS "9.3") # MATLAB 9.3 (R2017b) and newer have a new C++ API
   set(Matlab_HAS_CPP_API 1)
 endif()
 


### PR DESCRIPTION
[As described by the official release notes](https://www.mathworks.com/help/matlab/release-notes.html?rntext=C%2B%2B&startrelease=R2015aSP1&endrelease=R2018b&groupby=release&sortby=descending&searchHighlight=C%2B%2B), MATLAB Engine API for C++ is available as of R2017b. However, `FindMatlab.cmake` sets the requirement threshold at R2018a.  

`Matlab_ENGINE_LIBRARY` and `Matlab_DATAARRAY_LIBRARY` can be made available for R2017b. After small changes I made in this PR, I was able to link these libraries to my R2017b application. 

Please feel free to disregard this PR, in case R2018a limit is on purpose. 