### PR TITLE
[Intel]: Add INTEL Dpcpp compiler identification

### DIFF
--- a/Help/variable/CMAKE_LANG_COMPILER_ID.rst
+++ b/Help/variable/CMAKE_LANG_COMPILER_ID.rst
@@ -25,6 +25,7 @@ include:
   HP = Hewlett-Packard Compiler (hp.com)
   IAR = IAR Systems (iar.com)
   Intel = Intel Compiler (intel.com)
+  IntelDPCPP = Intel DPCPP Compiler (intel.com)
   MSVC = Microsoft Visual Studio (microsoft.com)
   NVIDIA = NVIDIA CUDA Compiler (nvidia.com)
   OpenWatcom = Open Watcom (openwatcom.org)

--- a/Modules/CMakeCompilerIdDetection.cmake
+++ b/Modules/CMakeCompilerIdDetection.cmake
@@ -77,6 +77,7 @@ function(compiler_id_detection outvar lang)
       ARMCC
       AppleClang
       ARMClang
+      IntelDPCPP
       Clang
       GNU
       MSVC

--- a/Modules/Compiler/IntelDPCPP-DetermineCompiler.cmake
+++ b/Modules/Compiler/IntelDPCPP-DetermineCompiler.cmake
@@ -1,0 +1,7 @@
+
+set(_compiler_id_pp_test "defined(__clang__) && defined(__INTEL_DPCPP_COMPILER__)")
+
+include("${CMAKE_CURRENT_LIST_DIR}/Clang-DetermineCompilerInternal.cmake")
+
+string(APPEND _compiler_id_version_compute "
+# define @PREFIX@COMPILER_VERSION_TWEAK @MACRO_DEC@(__INTEL_DPCPP_COMPILER__)")


### PR DESCRIPTION
check __INTEL_DPCPP_COMPILER__ via  _compiler_id_pp_test
to deect INTEL DPCPP compiler detection.

Thanks for your interest in contributing to CMake!  The GitHub repository
is a mirror provided for convenience, but CMake does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/cmake/cmake/-/tree/master/CONTRIBUTING.rst

for contribution instructions.  GitHub OAuth may be used to sign in.
