### PR TITLE
Improve compiler_id_detection resilience against variable setting.

### DIFF
--- a/Modules/CMakeCompilerIdDetection.cmake
+++ b/Modules/CMakeCompilerIdDetection.cmake
@@ -13,8 +13,8 @@ endfunction()
 
 function(compiler_id_detection outvar lang)
 
-  if (NOT lang STREQUAL Fortran AND NOT lang STREQUAL CSharp
-      AND NOT lang STREQUAL ISPC)
+  if (NOT lang STREQUAL "Fortran" AND NOT lang STREQUAL "CSharp"
+      AND NOT lang STREQUAL "ISPC")
     file(GLOB lang_files
       "${CMAKE_ROOT}/Modules/Compiler/*-DetermineCompiler.cmake")
     set(nonlang CXX)
@@ -42,7 +42,7 @@ function(compiler_id_detection outvar lang)
 
     # Order is relevant here. For example, compilers which pretend to be
     # GCC must appear before the actual GCC.
-    if (lang STREQUAL CXX)
+    if (lang STREQUAL "CXX")
       list(APPEND ordered_compilers
         Comeau
       )
@@ -70,7 +70,7 @@ function(compiler_id_detection outvar lang)
       Fujitsu
       GHS
     )
-    if (lang STREQUAL C)
+    if (lang STREQUAL "C")
       list(APPEND ordered_compilers
         TinyCC
         Bruce
@@ -92,13 +92,13 @@ function(compiler_id_detection outvar lang)
       ADSP
       IAR
     )
-    if (lang STREQUAL C)
+    if (lang STREQUAL "C")
       list(APPEND ordered_compilers
         SDCC
       )
     endif()
 
-    if(lang STREQUAL CUDA)
+    if(lang STREQUAL "CUDA")
       set(ordered_compilers NVIDIA Clang)
     endif()
 


### PR DESCRIPTION
Without this commit setting a variable named CUDA, C, CXX, Fortran, CSharp or ISPC
prevents the function compiler_id_detection for properly detection the compiler.

For example, with a simple project containing only:

cmake_minimum_required(VERSION 3.12...3.20)
project(projectname)
enable_language(CUDA)

The cmake configuration works properly with:

```
  cmake path_to_source_dir
```

but fails with

```
  cmake -DCUDA=ON path_to_source_dir
...
-- The CUDA compiler identification is GNU 8.3.0
-- Detecting CUDA compiler ABI info
CMake Error in /work1/celeritas/pcanal/geant/gcc8/builds/scalar-cuda11/VecGeom.newcmake/CMakeFiles/CMakeTmp/CMakeLists.txt:
  CUDA_ARCHITECTURES is empty for target "cmTC_cd788".

CMake Error in /work1/celeritas/pcanal/geant/gcc8/builds/scalar-cuda11/VecGeom.newcmake/CMakeFiles/CMakeTmp/CMakeLists.txt:
  CUDA_ARCHITECTURES is empty for target "cmTC_cd788".

CMake Error at /work1/celeritas/pcanal/geant/gcc8/install/cmake-3.19.3/share/cmake-3.19/Modules/CMakeDetermineCompilerABI.cmake:48 (try_compile):
  Failed to generate test project build system.
Call Stack (most recent call first):
  /work1/celeritas/pcanal/geant/gcc8/install/cmake-3.19.3/share/cmake-3.19/Modules/CMakeTestCUDACompiler.cmake:19 (CMAKE_DETERMINE_COMPILER_ABI)
  CMakeLists.txt:30 (enable_language)
-- Configuring incomplete, errors occurred!
```

and without the cmake_minimum_required, I get the equality obscure message:

-- The CUDA compiler identification is GNU 8.3.0
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - failed
-- Check for working CUDA compiler: /srv/software/cuda-toolkits/11.1.1/bin/nvcc
-- Check for working CUDA compiler: /srv/software/cuda-toolkits/11.1.1/bin/nvcc - broken
CMake Error at /work1/celeritas/pcanal/geant/gcc8/install/cmake-3.19.3/share/cmake-3.19/Modules/CMakeTestCUDACompiler.cmake:52 (message):
  The CUDA compiler

    "/srv/software/cuda-toolkits/11.1.1/bin/nvcc"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /work1/celeritas/pcanal/geant/gcc8/builds/scalar-cuda11/VecGeom.newcmake/CMakeFiles/CMakeTmp

    Run Build Command(s):/usr/bin/gmake cmTC_a3804/fast && /usr/bin/gmake  -f CMakeFiles/cmTC_a3804.dir/build.make CMakeFiles/cmTC_a3804.dir/build
    gmake[1]: Entering directory `/work1/celeritas/pcanal/geant/gcc8/builds/scalar-cuda11/VecGeom.newcmake/CMakeFiles/CMakeTmp'
    Building CUDA object CMakeFiles/cmTC_a3804.dir/main.cu.o
    /srv/software/cuda-toolkits/11.1.1/bin/nvcc      -c /work1/celeritas/pcanal/geant/gcc8/builds/scalar-cuda11/VecGeom.newcmake/CMakeFiles/CMakeTmp/main.cu -o CMakeFiles/cmTC_a3804.dir/main.cu.o
    Linking CUDA executable cmTC_a3804
    /work1/celeritas/pcanal/geant/gcc8/install/cmake-3.19.3/bin/cmake -E cmake_link_script CMakeFiles/cmTC_a3804.dir/link.txt --verbose=1
    "" CMakeFiles/cmTC_a3804.dir/main.cu.o -o cmTC_a3804
    Error running link command: No such file or directory
    gmake[1]: *** [cmTC_a3804] Error 2
    gmake[1]: Leaving directory `/work1/celeritas/pcanal/geant/gcc8/builds/scalar-cuda11/VecGeom.newcmake/CMakeFiles/CMakeTmp'
    gmake: *** [cmTC_a3804/fast] Error 2

  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  CMakeLists.txt:30 (enable_language)

Thanks for your interest in contributing to CMake!  The GitHub repository
is a mirror provided for convenience, but CMake does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/cmake/cmake/-/tree/master/CONTRIBUTING.rst

for contribution instructions.  GitHub OAuth may be used to sign in.
