### PR TITLE
make rule behave the same on Xcode and ninja

### DIFF
--- a/Source/cmGlobalNinjaGenerator.cxx
+++ b/Source/cmGlobalNinjaGenerator.cxx
@@ -401,7 +401,7 @@ void cmGlobalNinjaGenerator::WriteCustomCommandBuild(
 void cmGlobalNinjaGenerator::AddMacOSXContentRule()
 {
   cmNinjaRule rule("COPY_OSX_CONTENT");
-  rule.Command = cmStrCat(this->CMakeCmd(), " -E copy $in $out");
+  rule.Command = cmStrCat("if [ -f $in ]; then ", this->CMakeCmd(), " -E copy $in $out ; else ", this->CMakeCmd()," -E copy_directory $in $out ; fi");
   rule.Description = "Copying OS X Content $out";
   rule.Comment = "Rule for copying OS X bundle content file.";
   this->AddRule(rule);


### PR DESCRIPTION
When " set_source_files_properties( FILE_OR_DIR PROPERTIES MACOSX_PACKAGE_LOCATION Resources ) " is used on Xcode generator, it will copy file or directory structure, depends if "FILE_OR_DIR" is a file or directory. But if you generate ninja, the directory resource will be ignored.

Thanks for your interest in contributing to CMake!  The GitHub repository
is a mirror provided for convenience, but CMake does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/cmake/cmake/-/tree/master/CONTRIBUTING.rst

for contribution instructions.  GitHub OAuth may be used to sign in.
