### PR TITLE
Update FindCUDAToolkit.cmake

### DIFF
--- a/Modules/FindCUDAToolkit.cmake
+++ b/Modules/FindCUDAToolkit.cmake
@@ -863,7 +863,7 @@ if(CUDAToolkit_FOUND)
       PATH_SUFFIXES lib64/stubs lib/x64/stubs lib/stubs stubs
                     # Support NVHPC splayed math library layout
                     ../../math_libs/${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}/lib64
-                    ../../math_libs/lib64
+                    ${CUDAToolkit_TARGET_DIR}/../../math_libs/lib64
     )
 
     mark_as_advanced(CUDA_${lib_name}_LIBRARY)


### PR DESCRIPTION
Without specifying this to the search path, find_package FindCUDAToolkit can not find the CUDA math libraries (at least this was the case on Perlmutter @ NERSC). I am not sure if
../../math_libs/lib64
should stay in the search path and add this as well:
${CUDAToolkit_TARGET_DIR}/../../math_libs/lib64
or just have the latter. 

Thanks for your interest in contributing to CMake!  The GitHub repository
is a mirror provided for convenience, but CMake does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/cmake/cmake/-/tree/master/CONTRIBUTING.rst

for contribution instructions.  GitHub OAuth may be used to sign in.
