### PR TITLE
PACKAGE target fails to build when SDK style Projects are used

### DIFF
--- a/Source/cmVisualStudio10TargetGenerator.cxx
+++ b/Source/cmVisualStudio10TargetGenerator.cxx
@@ -495,7 +495,7 @@ void cmVisualStudio10TargetGenerator::WriteClassicMsBuildProjectFile(
       e1.Element("PreferredToolArchitecture", hostArch);
     }
 
-    // ALL_BUILD and ZERO_CHECK projects transitively include
+    // ALL_BUILD PACKAGE and ZERO_CHECK projects transitively include
     // Microsoft.Common.CurrentVersion.targets which triggers Target
     // ResolveNugetPackageAssets when SDK-style targets are in the project.
     // However, these projects have no nuget packages to reference and the
@@ -504,6 +504,7 @@ void cmVisualStudio10TargetGenerator::WriteClassicMsBuildProjectFile(
     // succeeds.
     cm::string_view targetName{ this->GeneratorTarget->GetName() };
     if (targetName == "ALL_BUILD" ||
+        targetName == "PACKAGE" ||
         targetName == CMAKE_CHECK_BUILD_SYSTEM_TARGET) {
       Elem e1(e0, "PropertyGroup");
       e1.Element("ResolveNugetPackages", "false");


### PR DESCRIPTION
The PACKAGE Target fails when trying to resolve nuget packages when SDK Style projects are used.
This PR changes the generation of the PACKAGE step to not trigger NuGet package restore. 
