### PR TITLE
Variable needs to be quoted to work for projects combining C and CXX

### DIFF
--- a/Modules/Compiler/IAR.cmake
+++ b/Modules/Compiler/IAR.cmake
@@ -9,7 +9,7 @@
 include_guard()
 
 macro(__compiler_iar_common lang)
-  if (${lang} MATCHES "^(C|CXX)$")
+  if ("${lang}" MATCHES "^(C|CXX)$")
     set(CMAKE_${lang}_COMPILE_OBJECT             "<CMAKE_${lang}_COMPILER> ${CMAKE_IAR_${lang}_FLAG} --silent <SOURCE> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT>")
     set(CMAKE_${lang}_CREATE_PREPROCESSED_SOURCE "<CMAKE_${lang}_COMPILER> ${CMAKE_IAR_${lang}_FLAG} --silent <SOURCE> <DEFINES> <INCLUDES> <FLAGS> --preprocess=cnl <PREPROCESSED_SOURCE>")
     set(CMAKE_${lang}_CREATE_ASSEMBLY_SOURCE     "<CMAKE_${lang}_COMPILER> ${CMAKE_IAR_${lang}_FLAG} --silent <SOURCE> <DEFINES> <INCLUDES> <FLAGS> -lAH <ASSEMBLY_SOURCE> -o <OBJECT>.dummy")


### PR DESCRIPTION
Creating a project with mixed sources (C/C++) fails to set up the compiler flags properly. Quoting the lang flag seems to make the comparison always work.
