### PR TITLE
On MingW64(MSYS2) Systems, the suffix of the OpenBLAS ILP64 library is different than under Linux. 

### DIFF
--- a/Modules/FindBLAS.cmake
+++ b/Modules/FindBLAS.cmake
@@ -746,7 +746,11 @@ if(BLA_VENDOR STREQUAL "OpenBLAS" OR BLA_VENDOR STREQUAL "All")
   set(_blas_openblas_lib "openblas")
 
   if(_blas_sizeof_integer EQUAL 8)
-    string(APPEND _blas_openblas_lib "64")
+    if(MINGW)
+      string(APPEND _blas_openblas_lib "_64")
+    else()
+      string(APPEND _blas_openblas_lib "64")
+    endif()
   endif()
 
   if(NOT BLAS_LIBRARIES)

--- a/Modules/FindLAPACK.cmake
+++ b/Modules/FindLAPACK.cmake
@@ -463,7 +463,7 @@ if(NOT LAPACK_NOT_FOUND_MESSAGE)
     set(_lapack_flexiblas_lib "flexiblas")
 
     if(_lapack_sizeof_integer EQUAL 8)
-      string(APPEND _lapack_openblas_lib "64")
+      string(APPEND _lapack_flexiblas_lib "64")
     endif()
 
     check_lapack_libraries(
@@ -488,9 +488,9 @@ if(NOT LAPACK_NOT_FOUND_MESSAGE)
 
     if(_lapack_sizeof_integer EQUAL 8)
       if(MINGW)
-        string(APPEND _lapack_flexiblas_lib "_64")
+        string(APPEND _lapack_openblas_lib "_64")
       else()
-        string(APPEND _lapack_flexiblas_lib "64")
+        string(APPEND _lapack_openblas_lib "64")
       endif()
     endif()
 

--- a/Modules/FindLAPACK.cmake
+++ b/Modules/FindLAPACK.cmake
@@ -463,7 +463,7 @@ if(NOT LAPACK_NOT_FOUND_MESSAGE)
     set(_lapack_flexiblas_lib "flexiblas")
 
     if(_lapack_sizeof_integer EQUAL 8)
-      string(APPEND _lapack_flexiblas_lib "64")
+      string(APPEND _lapack_openblas_lib "64")
     endif()
 
     check_lapack_libraries(
@@ -487,7 +487,11 @@ if(NOT LAPACK_NOT_FOUND_MESSAGE)
     set(_lapack_openblas_lib "openblas")
 
     if(_lapack_sizeof_integer EQUAL 8)
-      string(APPEND _lapack_openblas_lib "64")
+      if(MINGW)
+        string(APPEND _lapack_flexiblas_lib "_64")
+      else()
+        string(APPEND _lapack_flexiblas_lib "64")
+      endif()
     endif()
 
     check_lapack_libraries(


### PR DESCRIPTION
Typically, ILP64 BLAS libraries are suffixed with `64`, but the MSYS2 package provides the ILP64 version of OpenBLAS with a `_64` suffix.  This PR changes the suffix in 
 * `FindBLAS.cmake`
 * `FindLAPACK.cmake`
See https://packages.msys2.org/package/mingw-w64-x86_64-openblas64?repo=mingw64