### PR TITLE
Provides initial support for Fortran MEX

### DIFF
--- a/Modules/FindMatlab.cmake
+++ b/Modules/FindMatlab.cmake
@@ -1166,9 +1166,10 @@ function(matlab_add_mex)
       # If neither C or CXX is enabled, warn because we cannot add the source.
       # TODO: add support for fortran mex files
       if(DEFINED FORTRANMEX)
+        set(MEX_VERSION_FILE "${Matlab_ROOT_DIR}/extern/version/fortran_mexapi_version.F")
         message("[MATLAB] matlab_add_mex now build fortran mex files")
       else()
-        message(WARNING "[MATLAB] matlab_add_mex requires that at least C or CXX are enabled languages or set(FORTRANMEX ON)")
+        message(WARNING "[MATLAB] matlab_add_mex requires that at least C or CXX are enabled languages")
       endif()
     endif()
   endif()
@@ -1250,16 +1251,15 @@ function(matlab_add_mex)
   if(WIN32)
 
     if (MSVC)
-
-    if(DEFINED FORTRANMEX)
-    string(APPEND _link_flags " /EXPORT:MEXFUNCTION")
-    if(NOT Matlab_VERSION_STRING VERSION_LESS "9.1") # For 9.1 (R2016b) and newer, export version
-    string(APPEND _link_flags " /EXPORT:MEXFILEREQUIREDAPIVERSION")
-    endif()
-  else()
-    string(APPEND _link_flags " /EXPORT:mexFunction")
-    if(NOT Matlab_VERSION_STRING VERSION_LESS "9.1") # For 9.1 (R2016b) and newer, export version
-    string(APPEND _link_flags " /EXPORT:mexfilerequiredapiversion")
+      if(DEFINED FORTRANMEX)
+        string(APPEND _link_flags " /EXPORT:MEXFUNCTION")
+        if(NOT Matlab_VERSION_STRING VERSION_LESS "9.1") # For 9.1 (R2016b) and newer, export version
+        string(APPEND _link_flags " /EXPORT:MEXFILEREQUIREDAPIVERSION")
+      endif()
+    else()
+      string(APPEND _link_flags " /EXPORT:mexFunction")
+      if(NOT Matlab_VERSION_STRING VERSION_LESS "9.1") # For 9.1 (R2016b) and newer, export version
+      string(APPEND _link_flags " /EXPORT:mexfilerequiredapiversion")
     endif()
   endif()
 

--- a/Modules/FindMatlab.cmake
+++ b/Modules/FindMatlab.cmake
@@ -1165,7 +1165,11 @@ function(matlab_add_mex)
     else()
       # If neither C or CXX is enabled, warn because we cannot add the source.
       # TODO: add support for fortran mex files
-      message(WARNING "[MATLAB] matlab_add_mex requires that at least C or CXX are enabled languages")
+      if(DEFINED FORTRANMEX)
+        message("[MATLAB] matlab_add_mex now build fortran mex files")
+      else()
+        message(WARNING "[MATLAB] matlab_add_mex requires that at least C or CXX are enabled languages or set(FORTRANMEX ON)")
+      endif()
     endif()
   endif()
 
@@ -1247,10 +1251,17 @@ function(matlab_add_mex)
 
     if (MSVC)
 
-      string(APPEND _link_flags " /EXPORT:mexFunction")
-      if(NOT Matlab_VERSION_STRING VERSION_LESS "9.1") # For 9.1 (R2016b) and newer, export version
-        string(APPEND _link_flags " /EXPORT:mexfilerequiredapiversion")
-      endif()
+    if(DEFINED FORTRANMEX)
+    string(APPEND _link_flags " /EXPORT:MEXFUNCTION")
+    if(NOT Matlab_VERSION_STRING VERSION_LESS "9.1") # For 9.1 (R2016b) and newer, export version
+    string(APPEND _link_flags " /EXPORT:MEXFILEREQUIREDAPIVERSION")
+    endif()
+  else()
+    string(APPEND _link_flags " /EXPORT:mexFunction")
+    if(NOT Matlab_VERSION_STRING VERSION_LESS "9.1") # For 9.1 (R2016b) and newer, export version
+    string(APPEND _link_flags " /EXPORT:mexfilerequiredapiversion")
+    endif()
+  endif()
 
       set_property(TARGET ${${prefix}_NAME} APPEND PROPERTY LINK_FLAGS ${_link_flags})
 


### PR DESCRIPTION
Provides initial support for Fortran MEX

Testing environment: windows11 + intel fortran 2024.2 + intel oneMKL 2024.2 + matlab R2024b
Test Items:  [hls_ma48](https://www.hsl.rl.ac.uk/catalogue/hsl_ma48.html)
Test CMakeLists.txt:

```
cmake_minimum_required(VERSION 3.31)

set(CMAKE_GENERATOR_TOOLSET "fortran=ifx")
set(FORTRANMEX ON)
set(CMAKE_VERBOSE_MAKEFILE ON)
project(hsl_ma48 VERSION 1.0 LANGUAGES  Fortran)
set(SOURCES
    src/ddeps.f
    src/ddeps90.f90
    src/common90.f90
    src/hsl_ma48d.f90
)


add_library(hsl_ma48 STATIC  ${SOURCES})
find_package(MKL CONFIG REQUIRED)

target_link_libraries(hsl_ma48   PUBLIC  MKL::MKL) 

find_package(Matlab REQUIRED COMPONENTS MAT_LIBRARY MEX_COMPILER )

set(MATLAB_SORCES
    matlab/hsl_ma48_expert.f90
    matlab/hsl_matlab.F90
)
 
matlab_add_mex(NAME hsl_ma48_expert SHARED SRC ${MATLAB_SORCES}  LINK_TO hsl_ma48 R2017b)
```
Test results:

```
[main] building folder: d:/srcp/code/solvers/hsl_ma48-3.4.2/build hsl_ma48_expert
[build] is starting the build
[proc] command: "C:Program FilesCMakebincmake.EXE" --build d:/srcp/code/solvers/hsl_ma48-3.4.2/build --config Release --target hsl_ma48_expert -j 10 --
[build] 
[build] Microsoft Visual Studio 2022 version 17.12.3.
[build] Copyright (C) Microsoft Corp. All rights reserved.
[build] build starts at 17:02...
[build] 1>------ Build started: Project: ZERO_CHECK, Configuration: Release x64 ------
[build] ========== builds: 1 success, 0 failure, 2 latest, 0 skipped ==========
[build] ========== build completed at 17:02 and took 00.702 seconds ==========
[driver] generated: 00:00:06.073
[build] build completed with exit code 0
```