### PR TITLE
To include libuv, don't include kvm but uv. On GhostBSD kvm doesn't exist.

### DIFF
--- a/Utilities/cmlibuv/CMakeLists.txt
+++ b/Utilities/cmlibuv/CMakeLists.txt
@@ -219,7 +219,7 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   list(APPEND uv_libraries
-    kvm
+    uv
     )
   list(APPEND uv_headers
     include/uv/bsd.h


### PR DESCRIPTION

I could not compile CMake on GhostBSD because of this error:
```
87%] Building CXX object Source/CMakeFiles/CTestLib.dir/CTest/cmCTestBuildCommand.cxx.o
/usr/local/bin/ld: cannot find -lkvm: No such file or directory
[ 87%] Building CXX object Source/CMakeFiles/CTestLib.dir/CTest/cmCTestBuildHandler.cxx.o
collect2: error: ld returned 1 exit status
--- Tests/CMakeLib/testAffinity ---
*** [Tests/CMakeLib/testAffinity] Error code 1
```

The kvm library does not exist on GhostBSD. I imagine that on FreeBSD 
either.
https://cmake.org/pipermail/cmake-developers/2016-September/029355.html

CMake includes kvm to link to the uv library. 
But libuv does not generate a kvm library but a uv library.
See: https://freebsd.pkgs.org/14/freebsd-aarch64/libuv-1.50.0.pkg.html