### PR TITLE
ADSP: bugfix for assembler option

### DIFF
--- a/Modules/Compiler/ADSP.cmake
+++ b/Modules/Compiler/ADSP.cmake
@@ -10,7 +10,7 @@ macro(__compiler_adsp lang)
 
   set(CMAKE_${lang}_LINK_MODE DRIVER)
 
-  set(_CMAKE_${lang}_ADSP_FLAGS "-proc=${CMAKE_ADSP_PROCESSOR}")
+  set(_CMAKE_${lang}_ADSP_FLAGS "-proc ${CMAKE_ADSP_PROCESSOR}")
 
   set(CMAKE_DEPFILE_FLAGS_${lang} "-MD -Mo <DEP_FILE>")
 


### PR DESCRIPTION
change '-proc='  into '-proc '  because of error message from ADSP assembler. C Compiler and Linker is useing the same option...

Thanks for your interest in contributing to CMake!  The GitHub repository
is a mirror provided for convenience, but CMake does not use GitHub pull
requests for contribution.  Please see

  https://gitlab.kitware.com/cmake/cmake/-/tree/master/CONTRIBUTING.rst

for contribution instructions.  GitHub OAuth may be used to sign in.
